### PR TITLE
Bug fixes, Renter info page

### DIFF
--- a/flathunter/crawl_immobilienscout.py
+++ b/flathunter/crawl_immobilienscout.py
@@ -61,7 +61,7 @@ class CrawlImmobilienscout(Crawler):
     def get_expose_details(self, expose):
         soup = self.get_soup_from_url(expose['url'])
         date = soup.find('dd', { "class": "is24qa-bezugsfrei-ab" })
-        expose['from'] = datetime.datetime.now().strftime("%2d.%2d.%Y")
+        expose['from'] = datetime.datetime.now().strftime("%2d.%2m.%Y")
         if date is not None:
             if not re.match(r'.*sofort.*', date.text):
                 expose['from'] = date.text.strip()

--- a/flathunter/crawl_immowelt.py
+++ b/flathunter/crawl_immowelt.py
@@ -44,12 +44,12 @@ class CrawlImmowelt(Crawler):
                         continue
                     description = description_element.find("p").text
                     if re.match(r'.*sofort.*', description, re.MULTILINE|re.DOTALL|re.IGNORECASE):
-                        expose['from'] = datetime.datetime.now().strftime("%2d.%2d.%Y")
+                        expose['from'] = datetime.datetime.now().strftime("%2d.%2m.%Y")
                     date_string = re.match(r'.*(\d{2}.\d{2}.\d{4}).*', description, re.MULTILINE|re.DOTALL)
                     if date_string is not None:
                         expose['from'] = date_string[1]
             if 'from' not in expose:
-                expose['from'] = datetime.datetime.now().strftime("%2d.%2d.%Y")
+                expose['from'] = datetime.datetime.now().strftime("%2d.%2m.%Y")
         return expose
 
     def extract_data(self, soup):

--- a/flathunter/web/templates/about.html
+++ b/flathunter/web/templates/about.html
@@ -20,7 +20,7 @@ About
   </div>
   <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
-      <p>Flathunter helps you find somewhere to live in Germany, by periodically fetching apartment listings from the major property portals (ImmoScout, ImmoWelt, Ebay Kleinanzeigen and WG Gesucht) and sending the details of apartments that match your criteria to you in a Telegram message.</p>
+      <p>Flathunter helps you find somewhere to live in Berlin, by periodically fetching apartment listings from the major property portals (ImmoScout, ImmoWelt, Ebay Kleinanzeigen and WG Gesucht) and sending the details of apartments that match your criteria to you in a Telegram message.</p>
     </div>
   </div>
 

--- a/flathunter/web/templates/about.html
+++ b/flathunter/web/templates/about.html
@@ -5,9 +5,20 @@ About
 {% endblock %}
 
 {% block content %}
+<style>
+  div.row a {
+    color: cyan;
+  }
+
+  div.row a:visited {
+    color: cyan;
+  }
+</style>
 <div class="container">
   <div class="row text-white my-4">
     <h2 class="mx-auto">What is Flathunter?</h2>
+  </div>
+  <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
       <p>Flathunter helps you find somewhere to live in Germany, by periodically fetching apartment listings from the major property portals (ImmoScout, ImmoWelt, Ebay Kleinanzeigen and WG Gesucht) and sending the details of apartments that match your criteria to you in a Telegram message.</p>
     </div>
@@ -15,6 +26,8 @@ About
 
   <div class="row text-white my-4">
     <h2 class="mx-auto">Why use Flathunter?</h2>
+  </div>
+  <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
       <p>Looking for an apartment in Berlin is brutal right now. An appartment listing goes up on one of the many property portals &mdash; over 600 apartments are posted every day &mdash; and within minutes of a post going up, hundreds of people have applied. The system privileges those who have the time (or the software skills) to constantly check all the listings on every site. Flathunter levels the playing field by notifying anyone with a smartphone as soon as an interesting flat becomes available.</p>
     </div>
@@ -22,6 +35,8 @@ About
 
   <div class="row text-white my-4">
     <h2 class="mx-auto">How do I use Flathunter?</h2>
+  </div>
+  <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
       <p>Go to the <a href="/">homepage</a> and click 'Login with Telegram'. This will identify you to the system, and grant our Telegram bot permission to send you messages about interesting flats. Enter the details of your ideal flat into the form, and hit 'Set search critera' to restrict the notifications to the flats that meet your critera. If you don't want to receive Telegram messages any more, just hit 'Disable notifications'. That's it!</p>
     </div>
@@ -29,6 +44,8 @@ About
 
   <div class="row text-white my-4">
     <h2 class="mx-auto">Who are Flathunters?</h2>
+  </div>
+  <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
       <p><a href="https://github.com/flathunters">Flathunters</a> is a distributed team of coders who have themselves been looking for flats in Germany. Anyone can join, and <a href="https://github.com/flathunters/flathunter">all the code is open source</a>. If you have a support request, a feature wish, or you want to help out with the development, head over to <a href="https://github.com/flathunters/flathunter">our Github page</a>.</p>
     </div>
@@ -36,6 +53,8 @@ About
 
   <div class="row text-white my-4">
     <h2 class="mx-auto">What happens with my information?</h2>
+  </div>
+  <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
       <p>When you hit the 'Login with Telegram' button, we receive your Telegram username, first name, last name and <a href="https://telegram.org/blog/login">Telegram ID</a>. We store your Telegram ID, and we store your search preferences - we need that to send you messages about flats. Besides that, we don't store any information and we know nothing else about you.</p>
     </div>

--- a/flathunter/web/templates/exposes.html
+++ b/flathunter/web/templates/exposes.html
@@ -10,7 +10,7 @@
             <img src="/static/placeholder.png">
           {% endif %}
         </a>
-        <h3><a href="{{ expose['url'] }}" target="_blank">{{ expose['title'] }}</a></h3>
+        <h3><a href="{{ expose['url'] }}" rel="noreferrer" target="_blank">{{ expose['title'] }}</a></h3>
       </div>
     </div>
   {% endfor %}

--- a/flathunter/web/templates/index.html
+++ b/flathunter/web/templates/index.html
@@ -52,7 +52,7 @@ Home
   <div class="container">
     <div class="row">
       <div class="intro col-sm-9 mx-auto">
-        <p>Flathunter helps you find somewhere to live in Germany, by periodically fetching apartment listings from the major property portals (ImmoScout, ImmoWelt, Ebay Kleinanzeigen and WG Gesucht) and sending the details of apartments that match your criteria to you in a Telegram message.</p>
+        <p>Flathunter helps you find somewhere to live in Berlin, by periodically fetching apartment listings from the major property portals (ImmoScout, ImmoWelt, Ebay Kleinanzeigen and WG Gesucht) and sending the details of apartments that match your criteria to you in a Telegram message.</p>
       </div>
     </div>
   </div>

--- a/flathunter/web/templates/layout.html
+++ b/flathunter/web/templates/layout.html
@@ -29,6 +29,9 @@
           <li class="nav-item">
             <a class="nav-link" href="/about">About</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/resources">Resources</a>
+          </li>
         </ul>
       </div>
       <a class="navbar-brand" href="/">Flathunter</a>

--- a/flathunter/web/templates/resources.html
+++ b/flathunter/web/templates/resources.html
@@ -1,0 +1,91 @@
+{% extends 'layout.html' %}
+
+{% block title %}
+About
+{% endblock %}
+
+{% block content %}
+<style>
+  div.row a {
+    color: cyan;
+  }
+
+  div.row a:visited {
+    color: cyan;
+  }
+</style>
+<div class="container">
+  <div class="row text-white my-4">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>As a tenant in Germany, the law is designed to protect your right to have somewhere to live on terms that are fair.
+        Unfortunately, in a very competitive rental market, landlords try to skirt (or in some cases cross) the boundaries of what is legal.
+        Here are some resources to help you know what is fair and to protect your rights.</p>
+    </div>
+  </div>
+
+  <div class="row text-white my-4">
+    <h2 class="mx-auto">The Mietspiegel</h2>
+  </div>
+  <div class="row text-white my-2">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>The city of Berlin collects information about the average rent for different kinds of buildings in different parts of the city.
+      They provide an online service where you can fill in the details of the property you are about to rent, and get an estimate of what rent you should expect to pay.
+      <a href="https://www.stadtentwicklung.berlin.de/wohnen/mietspiegel/">Find out more about the Mietspiegel here</a></p>
+    </div>
+  </div>
+
+  <div class="row text-white my-4">
+    <h2 class="mx-auto">Mietwucher</h2>
+  </div>
+  <div class="row text-white my-2">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>Landlords will often try to significantly raise rents when finding a new tenant for their flat. There are limits on how much they can raise the prices, and
+      when the landlords go over those limits, they are breaking the law. If you offered a rent 20% higher than the average rent for similar apartments, the landlord might
+      be risking a fine. By offering a property for rent at 50% over the average rent for similar flats, they are committing a crime. <a href="https://www.stadtentwicklung.berlin.de/wohnen/mieterfibel/de/m_miete10.shtml">Read more about Mietwucher here.</a></p>
+    </div>
+  </div>
+
+  <div class="row text-white my-4">
+    <h2 class="mx-auto">Unfair contracts</h2>
+  </div>
+  <div class="row text-white my-2">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>Even if the price is fair, the contract you are offered might not be. Ask for a contract draft as early as possible, and compare it with <a href="https://www.hausgold.de/immobilien-mustervorlagen/untermietvertrag-mustervorlage/">a reference contract like this one</a>.
+      If you see terms in the contract that don't look familiar, there is a good chance they are not fair terms. The standard contract protects your rights, and protects the rights of the landlord to the extent permitted by the law.
+      In addition to what it might say in a contract, the basic law that applies to rental all contracts is <a href="https://www.gesetze-im-internet.de/bgb/__549.html">described in depth in the BGB here. Familiarise yourself with your rights</a>.</p>
+    </div>
+  </div>
+
+  <div class="row text-white my-4">
+    <h2 class="mx-auto">Zweckentfremdung - the Airbnb law</h2>
+  </div>
+  <div class="row text-white my-2">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>Since August 2018 in Berlin, landlords need a special permission to rent more than half of their flat for short-term (e.g. holiday) rentals, or to leave their flat empty of tenants. The law requires almost all flats that are not occupied by their owners to be made available on the rental market under the terms of normal private tenancy agreements.
+      Landlords who have a series of short-term tenants, at unusually high prices with non-standard agreements, or landlords who keep their flats off the market, are misusing their property under the terms of this law.
+      If you get to know of an apartment that is being misused in this way, <a href="https://service.berlin.de/dienstleistung/326217/">you can report it as a Zweckentfremdung here</a>.</p>
+    </div>
+  </div>
+
+  <div class="row text-white my-4">
+    <h2 class="mx-auto">Vorübergehende Gebrauch</h2>
+  </div>
+  <div class="row text-white my-2">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>Apparently in response to the Zweckentfremdung law, some landlords (and entire portals like <a href="https://wunderflats.com">Wunderflats</a>) attempt to offer time-limited rentals under the terms of <a href="https://www.gesetze-im-internet.de/bgb/__549.html">BGB §549 2.1</a>, which creates special exceptions to the rental law for people whose need of housing is "temporary".
+      If you are not an Olympic athlete in town for the Games, or an architect from Frankfurt finishing up a building project in Berlin - if you have no other place to live, if you plan to Anmeld, if you want to move your "Lebensmittelpunkt" to your new flat - your need is not temporary. BGB §549 2.1 does not apply to you and it should not be referred to in your rental contract.</p>
+    </div>
+  </div>
+
+  <div class="row text-white my-4">
+    <h2 class="mx-auto">Mietervereine</h2>
+  </div>
+  <div class="row text-white my-2">
+    <div class="intro col-sm-9 mx-auto text-left">
+      <p>When you have finally signed your contract, paid your deposit, and got your keys, your journey may not be over. There might be something wrong with the flat, the Hausverwaltung might be awful, the landlord might want to evict you after a year so they can raise the rents. The Mietervereine in Berlin are non-profit organisations whose members are all tenants in the city,
+      that offer qualified legal advice and support for tenants. Some of the Vereine even offer legal insurance as part of the membership. Whether or not you end up needing this support it makes sense to support one of these organisations, as they are busy working to keep landlords in check. Berlin is served by four different Vereine - <a href="http://www.mietervereine-in-berlin.de/">you can find an overview of them here</a>.</p>
+    </div>
+  </div>
+
+</div>
+{% endblock %}

--- a/flathunter/web/templates/resources.html
+++ b/flathunter/web/templates/resources.html
@@ -62,7 +62,7 @@ About
   <div class="row text-white my-2">
     <div class="intro col-sm-9 mx-auto text-left">
       <p>Since August 2018 in Berlin, landlords need a special permission to rent more than half of their flat for short-term (e.g. holiday) rentals, or to leave their flat empty of tenants. The law requires almost all flats that are not occupied by their owners to be made available on the rental market under the terms of normal private tenancy agreements.
-      Landlords who have a series of short-term tenants, at unusually high prices with non-standard agreements, or landlords who keep their flats off the market, are misusing their property under the terms of this law.
+      Landlords who have a series of short-term tenants, at unusually high prices with non-standard agreements, or landlords who keep their flats empty and off the market, are misusing their property under the terms of this law.
       If you get to know of an apartment that is being misused in this way, <a href="https://service.berlin.de/dienstleistung/326217/">you can report it as a Zweckentfremdung here</a>.</p>
     </div>
   </div>

--- a/flathunter/web/views.py
+++ b/flathunter/web/views.py
@@ -98,6 +98,10 @@ def index():
 def about():
     return render_template('about.html')
 
+@app.route('/resources')
+def resources():
+    return render_template('resources.html')
+
 # Accept GET requests here to support Google Cloud Cron calls
 @app.route('/hunt', methods=['GET','POST'])
 def hunt():

--- a/flathunter/web/views.py
+++ b/flathunter/web/views.py
@@ -19,7 +19,7 @@ class User(dict):
 
     def __init__(self, parameters):
         super().__init__(parameters)
-        for field in [ 'id', 'first_name', 'last_name' ]:
+        for field in [ 'id' ]:
             if field not in parameters:
                 raise AuthenticationError("Missing field: " + field)
 

--- a/flathunter/web_hunter.py
+++ b/flathunter/web_hunter.py
@@ -79,4 +79,7 @@ class WebHunter(Hunter):
         return not notifications_enabled
 
     def notifications_muted_for_user(self, user_id):
-        return ('mute_notifications' in self.id_watch.get_settings_for_user(user_id))
+        settings = self.id_watch.get_settings_for_user(user_id)
+        if settings is None:
+            return False
+        return ('mute_notifications' in settings)

--- a/flathunter/web_hunter.py
+++ b/flathunter/web_hunter.py
@@ -21,7 +21,9 @@ class WebHunter(Hunter):
                                         .calculate_durations() \
                                         .build()
 
-        new_exposes = processor_chain.process(self.crawl_for_exposes(max_pages=1))
+        new_exposes = []
+        for expose in processor_chain.process(self.crawl_for_exposes(max_pages=1)):
+            new_exposes.append(expose)
 
         for (user_id, settings) in self.id_watch.get_user_settings():
             if 'mute_notifications' in settings:

--- a/test/test_web_interface.py
+++ b/test/test_web_interface.py
@@ -151,7 +151,7 @@ def test_login_with_invalid_url(hunt_client):
     assert 'user' not in session
 
 def test_login_with_missing_params(hunt_client):
-    rv = hunt_client.get('/login_with_telegram?id=1234&hash=5f9093d108df178489e3235dbcff7251690852172e8e79bbaf753fd79e59f580')
+    rv = hunt_client.get('/login_with_telegram?ad=1234&hash=5f9093d108df178489e3235dbcff7251690852172e8e79bbaf753fd79e59f580')
     assert rv.status_code == 302
     assert rv.headers['location'] == 'http://localhost/'
     assert 'user' not in session

--- a/test/test_web_interface.py
+++ b/test/test_web_interface.py
@@ -179,7 +179,7 @@ def test_login_with_invalid_url(hunt_client):
     assert 'user' not in session
 
 def test_login_with_missing_params(hunt_client):
-    rv = hunt_client.get('/login_with_telegram?ad=1234&hash=5f9093d108df178489e3235dbcff7251690852172e8e79bbaf753fd79e59f580')
+    rv = hunt_client.get('/login_with_telegram?ad=1234&hash=51d737e1a3ba0821359955a36d3671f2957b5a8f1f32f9a133ce95836c44a9a9')
     assert rv.status_code == 302
     assert rv.headers['location'] == 'http://localhost/'
     assert 'user' not in session

--- a/test/test_web_interface.py
+++ b/test/test_web_interface.py
@@ -44,6 +44,10 @@ def test_get_about(hunt_client):
     rv = hunt_client.get('/about')
     assert b'<a class="navbar-brand" href="/">Flathunter</a>' in rv.data
 
+def test_get_resources(hunt_client):
+    rv = hunt_client.get('/resources')
+    assert b'<a class="navbar-brand" href="/">Flathunter</a>' in rv.data
+
 def test_get_index_with_exposes(hunt_client):
     app.config['HUNTER'].hunt_flats()
     rv = hunt_client.get('/')

--- a/test/test_web_interface.py
+++ b/test/test_web_interface.py
@@ -76,6 +76,14 @@ def test_hunt_via_post(hunt_client, **kwargs):
     rv = hunt_client.get('/hunt')
     assert '<div class="expose' in json.loads(rv.data)['body']
 
+def test_render_index_after_login(hunt_client):
+    rv = hunt_client.get('/login_with_telegram?id=1234&first_name=Jason&last_name=Bourne&username=mattdamon&photo_url=https%3A%2F%2Fi.example.com%2Fprofile.jpg&auth_date=123455678&hash=c691a55de4e28b341ccd0b793d4ca17f09f6c87b28f8a893621df81475c25952')
+    assert rv.status_code == 302
+    assert rv.headers['location'] == 'http://localhost/'
+    assert 'user' in session
+    rv = hunt_client.get('/')
+    assert rv.status_code == 200
+ 
 @requests_mock.Mocker(kw='m')
 def test_do_not_send_messages_if_notifications_disabled(hunt_client, **kwargs):
     m = kwargs['m']


### PR DESCRIPTION
Added page with information about rights for tenants
Fixed bug with exposes only being sent through one user filter
Fixed date bug in exposes for 'sofort' rentals
Don't send referrer when users click on expose links
Make it clear that the 'flathunter' website is currently setup for Berlin only