### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+COPY . /app
+WORKDIR /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+VOLUME /config
+
+CMD [ "python3", "-u", "flathunter.py", "-c", "/config/config.yaml" ]


### PR DESCRIPTION
This adds a basic Dockerfile that has to be `docker build` by the user.

So far it is only starting flathunter without the UI and without an option to persist the database to survive restarts (#23 will make this easier).

I'm planning to add the building of the image to Travis in a separate PR.