### PR TITLE
Fix a bug where an entry without a price caused a crash.

### DIFF
--- a/flathunter/crawl_immobilienscout.py
+++ b/flathunter/crawl_immobilienscout.py
@@ -111,6 +111,7 @@ class CrawlImmobilienscout(Crawler):
             else:
                 image = None
 
+            # Entries without price, size, or room count will get skipped.
             if len(attr_els) > 2:
                 details = {
                     'id': expose_ids[idx],
@@ -123,6 +124,8 @@ class CrawlImmobilienscout(Crawler):
                     'address': address,
                     'crawler': self.get_name()
                 }
+            else:
+                continue
             # print entries
             exist = False
             for expose in entries:


### PR DESCRIPTION
Now, entries without price, size, or room count are more explicitly skipped.