### PR TITLE
Fixed immoscout24 crawler also crawling in the "Weitere Angebote..." section

### DIFF
--- a/flathunter/crawl_immobilienscout.py
+++ b/flathunter/crawl_immobilienscout.py
@@ -77,7 +77,7 @@ class CrawlImmobilienscout(Crawler):
         """Extracts all exposes from a provided Soup object"""
         entries = list()
 
-        title_elements = soup.find_all(
+        title_elements = soup.find(id="resultListItems").find_all(
             lambda e: e.name == 'a' and e.has_attr('class') and \
                       'result-list-entry__brand-title-container' in e['class'])
         expose_ids = list()


### PR DESCRIPTION
Before the yellow part was included in the search. Those are sponsored results, that often don't fit the search criteria.

![grafik](https://user-images.githubusercontent.com/18146212/91498180-9b4af580-e8bf-11ea-8999-7e50107d2514.png)
