### PR TITLE
fix empty json response when no captcha

### DIFF
--- a/flathunter/abstract_crawler.py
+++ b/flathunter/abstract_crawler.py
@@ -69,7 +69,7 @@ class Crawler:
             self.__log__.error("Got response (%i): %s", resp.status_code, resp.content)
         if self.config.use_proxy():
             return self.get_soup_with_proxy(url)
-        if driver is not None and re.search("g-recaptcha", resp.text):
+        if driver is not None:
             driver.get(url)
             if re.search("g-recaptcha", driver.page_source):
                 self.resolvecaptcha(driver, checkbox, afterlogin_string, captcha_api_key)


### PR DESCRIPTION
the get_entries_from_javascript() expected to get a result from the driver's get method, but fails since it got called only when Captcha was present. This is not the case all the time, specially at the start, therefore ran into the JavascriptException.