### PR TITLE
Adjust Dockerfile to use chromedriver for captchas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3
+FROM joyzoursky/python-chromedriver:3.8
 
 COPY . /app
 WORKDIR /app
+
+RUN export PATH=$PATH:/usr/lib/chromium-browser/
 
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Thanks for the awesome project. I recently adjusted the Dockerfile to make it run chrome web driver which is necessary for the 2captcha service.

I would like to contribute it if you want. It could also be renamed to keep the original version which is still working if chrome web driver is not necessary.