### PR TITLE
Remove pkg-resources==0.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,6 @@ more-itertools==8.4.0
 msgpack==1.0.2
 multidict==4.7.6
 packaging==20.9
-pkg-resources==0.0.0
 pluggy==0.13.1
 ply==3.11
 proto-plus==1.13.0


### PR DESCRIPTION
pkg-resources==0.0.0 in requirements.txt breaks the install of the dependencies (pip3 install -r requirements.txt). It seems, the dependency is added when freezing the requirements on Ubuntu https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463.