### PR TITLE
Avoid accidentally generating a URL with a double slash after the domain

### DIFF
--- a/flathunter/crawl_wggesucht.py
+++ b/flathunter/crawl_wggesucht.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from flathunter.abstract_crawler import Crawler
+from flathunter.string_utils import remove_prefix
 
 
 class CrawlWgGesucht(Crawler):
@@ -30,7 +31,7 @@ class CrawlWgGesucht(Crawler):
         for row in existing_findings:
             title_row = row.find('h3', {"class": "truncate_title"})
             title = title_row.text.strip()
-            url = base_url + title_row.find('a')['href']
+            url = base_url + remove_prefix(title_row.find('a')['href'], "/")
             image = re.match(r'background-image: url\((.*)\);',
                              row.find('div', {"class": "card_image"}).find('a')['style'])[1]
             detail_string = row.find("div", {"class": "col-xs-11"}).text.strip().split("|")

--- a/flathunter/string_utils.py
+++ b/flathunter/string_utils.py
@@ -1,0 +1,6 @@
+def remove_prefix(text, prefix):
+    """Note that this method can just be replaced by str.removeprefix()
+    if the project ever moves to Python 3.9+"""
+    if text and text.startswith(prefix):
+        return text[len(prefix):]
+    return text

--- a/test/test_string_utils.py
+++ b/test/test_string_utils.py
@@ -1,0 +1,16 @@
+import unittest
+
+from flathunter.string_utils import remove_prefix
+
+
+class StringUtilsTest(unittest.TestCase):
+
+    def test_remove_prefix(self):
+        self.assertEqual(remove_prefix("abcdef", "abc"), "def")
+        self.assertEqual(remove_prefix("acdef", "abc"), "acdef")
+        self.assertEqual(remove_prefix("abcdef", ""), "abcdef")
+        self.assertEqual(remove_prefix("abc", "abc"), "")
+        self.assertEqual(remove_prefix("abc", "abcd"), "abc")
+        self.assertEqual(remove_prefix("", "abc"), "")
+        self.assertEqual(remove_prefix("", ""), "")
+        self.assertEqual(remove_prefix(None, "foo"), None)


### PR DESCRIPTION
This will ensure a single slash in the constructed url regardless of
whether the href attribute contains a leading slash or not.