### PR TITLE
Fixed debug output on immowelt crawler

### DIFF
--- a/flathunter/crawl_immowelt.py
+++ b/flathunter/crawl_immowelt.py
@@ -101,6 +101,6 @@ class CrawlImmowelt(Crawler):
             }
             entries.append(details)
 
-        self.__log__.debug('extracted: %d', entries)
+        self.__log__.debug('extracted: %d', len(entries))
 
         return entries


### PR DESCRIPTION
When setting logging to debug, outputting the number of extracted entries fails, as it passed the raw entries, not `len(entries)`as in the other crawlers, and thus doesn't fit with `%d`.