### PR TITLE
Make title match case insensitive

### DIFF
--- a/flathunter/filter.py
+++ b/flathunter/filter.py
@@ -118,7 +118,7 @@ class TitleFilter:
     def is_interesting(self, expose):
         """True unless title matches the filtered titles"""
         combined_excludes = "(" + ")|(".join(self.filtered_titles) + ")"
-        found_objects = re.search(combined_excludes, expose['title'].lower())
+        found_objects = re.search(combined_excludes, expose['title'], re.IGNORECASE)
         # send all non matching regex patterns
         if not found_objects:
             return True


### PR DESCRIPTION
Currently all filtered tags will be compared to the lowercase title. This implies, that a match is only possible if filtered tags are written all lowercase.

Instead, this PR compares the filtered tags to the original title but case-insensitve. No need to convert title to lowercase, nor to restrict the user to only enter lower-case filtered tags