### PR TITLE
WIP/Untested: add driver.close() to close driver and prevent accumulation

### DIFF
--- a/flathunter/abstract_crawler.py
+++ b/flathunter/abstract_crawler.py
@@ -83,6 +83,7 @@ class Crawler:
                 self.resolve_geetest(driver)
             elif re.search("g-recaptcha", driver.page_source):
                 self.resolve_recaptcha(driver, checkbox, afterlogin_string)
+            driver.close()
             return BeautifulSoup(driver.page_source, 'html.parser')
         return BeautifulSoup(resp.content, 'html.parser')
 


### PR DESCRIPTION
This should hopefully curb the problem of ever-expanding web-driver instances. I haven't had time to test this yet, but wanted to open this PR so others could test it if they like.