### PR TITLE
Automate ChromeDriver install by using WebDriverManager

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ backoff = "*"
 pytz = "*"
 beautifulsoup4 = "*"
 pylint-runner = "*"
+webdriver-manager = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5d068cfd230f05ba7646c3d59f379e1822550b475bd35cba146e9942fa555de9"
+            "sha256": "4beba6fc9f20fac205537f5ee28d14214df496cb2f15405f68600ee3423ad1cb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,7 +61,7 @@
                 "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b",
                 "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==0.12.11"
         },
         "cachetools": {
@@ -77,7 +77,7 @@
                 "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
                 "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2022.6.15"
         },
         "cffi": {
@@ -154,7 +154,7 @@
                 "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
                 "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.0"
         },
         "click": {
@@ -400,7 +400,7 @@
                 "sha256:fec221a051150eeddfdfcff162e6db92c65ecf46cb0f7bb1bf812a1520ec026b",
                 "sha256:ff71073ebf0e42258a42a0b34f2c09ec384977e7f6808999102eedd5b49920e3"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.3.0"
         },
         "google-resumable-media": {
@@ -408,7 +408,7 @@
                 "sha256:27c52620bd364d1c8116eaac4ea2afcbfb81ae9139fb3199652fcac1724bfb6c",
                 "sha256:5b52774ea7a829a8cdaa8bd2d4c3d4bc660c91b30857ab2668d0eb830f4ea8c5"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.3.3"
         },
         "googleapis-common-protos": {
@@ -482,7 +482,7 @@
                 "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06",
                 "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==0.13.0"
         },
         "httplib2": {
@@ -521,7 +521,7 @@
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
                 "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==5.10.1"
         },
         "itsdangerous": {
@@ -589,7 +589,7 @@
                 "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b",
                 "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.7.1"
         },
         "lxml": {
@@ -719,7 +719,7 @@
                 "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
                 "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
         },
         "mock-firestore": {
@@ -800,7 +800,7 @@
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==21.3"
         },
         "platformdirs": {
@@ -816,7 +816,7 @@
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
         },
         "ply": {
@@ -831,7 +831,7 @@
                 "sha256:449b4537e83f4776bd69051c4d776db8ffe3f9d0641f1e87b06c116eb94c90e9",
                 "sha256:c6c43c3fcfc360fdab46b47e2e9e805ff56e13169f9f2e45caf88b6b593215ab"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.20.6"
         },
         "protobuf": {
@@ -970,6 +970,14 @@
             "index": "pypi",
             "version": "==3.8.2"
         },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f",
+                "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.20.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
@@ -1046,7 +1054,7 @@
                 "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
                 "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.9"
         },
         "selenium": {
@@ -1092,7 +1100,7 @@
                 "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759",
                 "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.3.2.post1"
         },
         "tomli": {
@@ -1100,7 +1108,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
         "tomlkit": {
@@ -1108,7 +1116,7 @@
                 "sha256:1c5bebdf19d5051e2e1de6cf70adfc5948d47221f097fcff7a3ffc91e953eaf5",
                 "sha256:61901f81ff4017951119cd0d1ed9b7af31c821d6845c8c477587bbdcd5e5854e"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==0.11.1"
         },
         "trio": {
@@ -1140,16 +1148,24 @@
                 "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0",
                 "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.1.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
             ],
             "index": "pypi",
-            "version": "==1.26.10"
+            "version": "==1.26.11"
+        },
+        "webdriver-manager": {
+            "hashes": [
+                "sha256:5282e957fe59bc5cd96eae58b2ec4cc6f0de649fa832e5ab40d6284f6ee7830e",
+                "sha256:df23786e34d4c1f8c4490e1922618c2fe5a58a2bf6444b94c6664fc3fefba2e4"
+            ],
+            "index": "pypi",
+            "version": "==3.8.2"
         },
         "werkzeug": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ curl https://api.telegram.org/bot[BOT-TOKEN]/getUpdates
 to get list of messages the Bot has received. You will see your Chat ID in there.
 
 #### 2Captcha
-Some sites (including ImmoScout24) implement Captcha to avoid being crawled by evil web scrapers. Since our crawler is not an evil one, the people at [2captcha](https://2captcha.com) provide us a service that helps you solve them. Head to the `2captchas` website, register and pay 3$ for 1000 solved captcha's! Check the `config.yaml.dist` on how to configure `2captcha` with `flathunter`. You will also be required to install a [chrome-web-driver](https://chromedriver.chromium.org/downloads) on your system that runs `flathunter`. The installation procedure varies depending on your system, a quick search on the internet should answer this question. **At this time, ImmoScout24 cannot be crawled by flathunter without using 2Captcha**.
+Some sites (including ImmoScout24) implement Captcha to avoid being crawled by evil web scrapers. Since our crawler is not an evil one, the people at [2captcha](https://2captcha.com) provide us a service that helps you solve them. Head to the `2captchas` website, register and pay 3$ for 1000 solved captcha's! Check the `config.yaml.dist` on how to configure `2captcha` with `flathunter`. **At this time, ImmoScout24 cannot be crawled by flathunter without using 2Captcha**.
 
 #### Proxy
 It's common that websites use bots and crawler protections to avoid being flooded with possibly malicious traffic. This can cause some issues when crawling, as we will be presented with a bot-protection page.

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -118,14 +118,12 @@ google_maps_api:
 # solving service. Register at either imagetypers or 2captcha 
 # (the former is prefered), desposit some funds, uncomment the 
 # corresponding lines below and replace your API key/token.
-# you will also have to install a Chrome Web Driver and write below 
-# the executable path, the driver_arguments can be left as is.
+# Use driver_arguments to provide options for Chrome WebDriver.
 # captcha:
 #       imagetypers:
 #             token: alskdjaskldjfklj
 #       2captcha:
 #             api_key: alskdjaskldjfklj
-#       driver_path: YOUR_CHROME_DRIVER_PATH
 #       driver_arguments:
 #         - "--headless"
 

--- a/flathunt.py
+++ b/flathunt.py
@@ -10,7 +10,7 @@ import logging
 import time
 from pprint import pformat
 
-from flathunter.logging import logger
+from flathunter.logging import logger, wdm_logger
 from flathunter.idmaintainer import IdMaintainer
 from flathunter.hunter import Hunter
 from flathunter.config import Config
@@ -67,7 +67,13 @@ def main():
     # adjust log level, if required
     if config.get('verbose'):
         logger.setLevel(logging.DEBUG)
-        logger.debug("Settings from config: %s", pformat(config))
+        # Allow logging of "webdriver-manager" module on verbose mode
+        wdm_logger.setLevel(logging.INFO)
+
+    logger.debug("Settings from config: %s", pformat(config))
+
+    # initialize search plugins for config
+    config.init_searchers()
 
     # check config
     notifiers = config.get('notifiers', [])

--- a/flathunter/crawl_immobilienscout.py
+++ b/flathunter/crawl_immobilienscout.py
@@ -24,8 +24,6 @@ class CrawlImmobilienscout(Crawler):
 
         if config.captcha_enabled():
             captcha_config = config.get('captcha')
-
-            driver_executable_path = captcha_config.get('driver_path', '')
             driver_arguments = captcha_config.get('driver_arguments', [])
 
             if captcha_config.get('checkbox', '') == "":
@@ -37,10 +35,7 @@ class CrawlImmobilienscout(Crawler):
             else:
                 self.afterlogin_string = captcha_config.get('afterlogin_string', '')
             if self.captcha_solver:
-                self.driver = self.configure_driver(
-                    driver_executable_path,
-                    driver_arguments
-                )
+                self.driver = self.configure_driver(driver_arguments)
 
     def get_results(self, search_url, max_pages=None):
         """Loads the exposes from the ImmoScout site, starting at the provided URL"""

--- a/flathunter/logging.py
+++ b/flathunter/logging.py
@@ -2,26 +2,51 @@
 import logging
 import os
 
-if os.name == 'posix':
-    # provide coloring for UNIX systems
-    _CYELLOW = '\033[93m'
-    _CBLUE = '\033[94m'
-    _COFF = '\033[0m'
-else:
-    _CYELLOW = ''
-    _CBLUE = ''
-    _COFF = ''
+class LoggerHandler(logging.StreamHandler):
+    """Formats logs and alters WebDriverManager's logs properties"""
 
-LOG_FORMAT = '[' + _CBLUE + '%(asctime)s' + _COFF + '|' + _CBLUE + '%(filename)-18s' + _COFF + \
-                '|' + _CYELLOW + '%(levelname)-8s' + _COFF + ']: %(message)s'
+    _CYELLOW = '\033[93m' if os.name == 'posix' else ''
+    _CBLUE = '\033[94m' if os.name == 'posix' else ''
+    _COFF = '\033[0m' if os.name == 'posix' else ''
+    _FORMAT = '[' + _CBLUE + '%(asctime)s' + _COFF + \
+              '|' + _CBLUE + '%(filename)-24s' + _COFF + \
+              '|' + _CYELLOW + '%(levelname)-8s' + _COFF + \
+              ']: %(message)s'
+    _DATE_FORMAT = '%Y/%m/%d %H:%M:%S'
 
-logging.basicConfig(
-    format=LOG_FORMAT,
-    datefmt='%Y/%m/%d %H:%M:%S',
-    level=logging.INFO
-)
+    def __init__(self):
+        super().__init__()
+        self.setFormatter(logging.Formatter(
+            fmt=self._FORMAT,
+            datefmt=self._DATE_FORMAT
+        ))
 
-# Set logging level for "requests" module
-logging.getLogger("requests").setLevel(logging.WARNING)
+    def emit(self, record):
+        # Log record came from webdriver-manager logger
+        if record.name == "WDM":
+            # Filename to display in log
+            record.filename="<WebDriverManager>"
+            # Always display loglevel as DEBUG
+            record.levelname="DEBUG"
+        super().emit(record)
 
+def setup_wdm_logger(wdm_new_logger_handler):
+    """Setup "webdriver-manager" module's logger"""
+    wdm_log = logging.getLogger('WDM')
+    # Only allow critical-level logs by default (mute)
+    wdm_log.setLevel(logging.CRITICAL)
+    wdm_log.propagate = False
+    # wdm_log.removeHandler(wdm_logger_handler)
+    wdm_log.addHandler(wdm_new_logger_handler)
+    return wdm_log
+
+# Setup Flathunter logger
+logger_handler = LoggerHandler()
+logging.basicConfig(level=logging.INFO, handlers=[logger_handler])
 logger = logging.getLogger('flathunt')
+
+# Setup "webdriver-manager" module's logger
+wdm_logger = setup_wdm_logger(logger_handler)
+
+# Setup "requests" module's logger
+logging.getLogger("requests").setLevel(logging.WARNING)


### PR DESCRIPTION
**This update aims to reduce installation complexity by rendering a manual ChromeDriver install obsolete.** [WebDriverManager](https://pypi.org/project/webdriver-manager/) ("WDM") automatically takes care of the driver's installation in the background. By default it does not produce any output, *unless verbose mode is active*.

**Changes:**
- Added ```webdriver-manager``` package
- Implemented WDM as service instead of static driver path for ChromeDriver launch
  - This also removes a "deprecated" warning issued by Selenium's WebDriver module ["DeprecationWarning: executable_path has been deprecated, please pass in a Service object"](https://github.com/flathunters/flathunter/blob/a73b6cfd23e36ca3dceca62096af7edfac7a3603/flathunter/abstract_crawler.py#L56)
- Removed ChromeDriver install instructions from README
- Removed ChromeDriver path from config file
- Implemented warning for users still using ChromeDriver path in config file (blue box in screenshot below)
- Refactored logging logic
   - Allowed for WDM logging to be handled
      - Logs won't be shown by default, unless when using verbose mode (will then be displayed as DEBUG logs as seen in red box in screenshot below)
![WDM logs](https://i.imgur.com/YLXLrNM.png)