### PR TITLE
Docker-related updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,116 @@
+# Git/GitHub
+.git
+.github
+
+# Google Cloud
+.gcloudignore
+/app.yaml
+/cron.yaml
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Chrome
+.webkit_cache/
+
+# Database
+processed_ids.db
+
+# IDEs
+.idea/
+
+# Vim
+.*.swp
+
+# Vscode
+.vscode
+
+# Configuration
+/config.yaml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # Git/GitHub
 .git
 .github
+.gitignore
 
 # Google Cloud
 .gcloudignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM joyzoursky/python-chromedriver:3.8
+FROM python:3.7
 
-COPY . /app
-WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ARG PIP_NO_CACHE_DIR=1
 
-RUN export PATH=$PATH:/usr/lib/chromium-browser/
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+RUN apt-get -y update
+RUN apt-get install -y google-chrome-stable
 
-RUN pip install --no-cache-dir -r requirements.txt
+WORKDIR /usr/src/app
+COPY . .
 
-VOLUME /config
+RUN pip install --upgrade pip && \
+    pip install pipenv && \
+    python --version; pip --version; pipenv --version
 
-CMD [ "python3", "-u", "flathunt.py", "-c", "/config/config.yaml" ]
+RUN pipenv requirements > requirements.txt
+RUN pip install -r requirements.txt
+
+CMD [ "python3", "flathunt.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ RUN apt-get install -y google-chrome-stable
 WORKDIR /usr/src/app
 COPY . .
 
-RUN pip install --upgrade pip && \
-    pip install pipenv && \
-    python --version; pip --version; pipenv --version
+RUN pip install --upgrade pip
+RUN pip install pipenv
 
 RUN pipenv requirements > requirements.txt
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,21 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ARG PIP_NO_CACHE_DIR=1
 
+# Install Google Chrome
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
 RUN apt-get -y update
 RUN apt-get install -y google-chrome-stable
 
+# Copy files
 WORKDIR /usr/src/app
 COPY . .
 
+# Upgrade pip, install pipenv
 RUN pip install --upgrade pip
 RUN pip install pipenv
 
+# Generate requirements.txt and install dependencies from there
 RUN pipenv requirements > requirements.txt
 RUN pip install -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip install --upgrade pip && \
 RUN pipenv requirements > requirements.txt
 RUN pip install -r requirements.txt
 
-CMD [ "python3", "flathunt.py" ]
+CMD [ "python", "flathunt.py", "-c", "/config.yaml" ]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ To use the distance calculation feature a [Google API-Key](https://developers.go
 
 Since this feature is not free, it is "disabled". Read line 62 in hunter.py to re-enable it.
 
+### Docker
+
+First build the image inside the project's root directory:
+```sh
+$ docker build -t flathunter .
+```
+
+***When running a container using the image, the ```config.yaml``` file needs to be mounted to ```/config.yaml```.** The example below  provides the file off the current working directory:
+
+```sh
+$ docker run --mount type=bind,source=$PWD/config.yaml,target=/config.yaml flathunter
+```
+
 ### Google Cloud Deployment
 
 You can run `flathunter` on Google's App Engine, in the free tier, at no cost. To get started, first install the [Google Cloud SDK](https://cloud.google.com/sdk/docs) on your machine, and run:


### PR DESCRIPTION
There have been [issues](https://github.com/flathunters/flathunter/issues/121) around Flathunter's Docker setup, which also now had stopped working entirely since ```requirements.txt``` was removed from the repository.

- **Changed Dockerfile base from ```joyzoursky/python-chromedriver``` to plain ```python```.** Now that WebDriverManager is used to automatically setup ChromeDriver, it is also no longer necessary to build off joyzoursky's ```python-chromedriver``` image. 
- **Added Google Chrome install to Dockerfile.** This is required for WebDriverManager's ChromeDriver setup to work and had been taken care of before by basing the Dockerfile off the ```python-chromedriver``` image.
- **Allowed for Dockerfile to install dependencies without ```requirements.txt```.** Building the image stopped working [since ```requirements.txt``` was removed from files](https://github.com/flathunters/flathunter/commit/bfb1a60074fb1c73f13e611fffb1b7430f2ea0b7). 
- **Removed ```VOLUME``` from Dockerfile, replaced it by mount instructions in [README](https://github.com/flathunters/flathunter/blob/b48c5d23fdcf83efdead694fbb8abf6e48d3262e/README.md?plain=1#L132).** (https://stackoverflow.com/a/46992367)
- **Added ```.dockerignore```**