### PR TITLE
Add date 'to' in the title of wg-gesucht

### DIFF
--- a/flathunter/crawl_wggesucht.py
+++ b/flathunter/crawl_wggesucht.py
@@ -52,11 +52,16 @@ class CrawlWgGesucht(Crawler):
                 logger.warning("No size found - skipping")
                 continue
 
+            if len(dates) == 2:
+                title = f"{title} vom {dates[0]} bis {dates[1]}"
+            else:
+                title = f"{title} ab dem {dates[0]}"
+
             details = {
                 'id': int(url.split('.')[-2]),
                 'image': image,
                 'url': url,
-                'title': f"{title} ab dem {dates[0]}",
+                'title': title,
                 'price': price,
                 'size': size[0],
                 'rooms': rooms,


### PR DESCRIPTION
wg-gesucht is commonly used also for short-term rent. 

If a user is searching short term rent the period is really important, and with this modification, it would appear in the notification. 

Even if a user is searching only for Long term renting, wg-gesucht does not allow filtering with the move-out date so having this information would allow discarding a rent quickly just by looking at the notification.

If there is a move-out date the title would become:
```
if len(dates) == 2:
    title = f"{title} vom {dates[0]} bis {dates[1]}"
else:
    title = f"{title} ab dem {dates[0]}"
```

An alternative solution would be to expose the `from` and `to` placeholders in the message configuration.