### PR TITLE
Make telegram use apprise instead of requests

### DIFF
--- a/flathunter/exceptions.py
+++ b/flathunter/exceptions.py
@@ -1,17 +1,6 @@
-class BotBlockedException(Exception):
+class NotificationException(Exception):
     """
-    A small class that defines a Bot Blocked Exception.
-    """
-    def __init__(self, message):
-        self.value = str(message)
-        Exception.__init__(self, self.value)
-
-    def __str__(self):
-        return self.value
-
-class UserDeactivatedException(Exception):
-    """
-    A small class that defines a UserDeactivated Exception.
+    A small class that defines a Notification Exception.
     """
     def __init__(self, message):
         self.value = str(message)

--- a/flathunter/sender_telegram.py
+++ b/flathunter/sender_telegram.py
@@ -1,12 +1,7 @@
 """Functions and classes related to sending Telegram messages"""
-import urllib.request
-import urllib.parse
-import urllib.error
-import requests
-
 from flathunter.logging import logger
 from flathunter.abstract_processor import Processor
-from flathunter.exceptions import BotBlockedException, UserDeactivatedException
+from flathunter.sender_apprise import SenderApprise
 
 class SenderTelegram(Processor):
     """Expose processor that sends Telegram messages"""
@@ -36,26 +31,10 @@ class SenderTelegram(Processor):
         """Send messages to each of the receivers in receiver_ids"""
         if self.receiver_ids is None:
             return
-        for chat_id in self.receiver_ids:
-            url = 'https://api.telegram.org/bot%s/sendMessage?chat_id=%i&text=%s'
-            text = urllib.parse.quote_plus(message.encode('utf-8'))
-            logger.debug(('token:', self.bot_token))
-            logger.debug(('chatid:', chat_id))
-            logger.debug(('text', text))
-            qry = url % (self.bot_token, chat_id, text)
-            logger.debug("Retrieving URL %s", qry)
-            resp = requests.get(qry)
-            logger.debug("Got response (%i): %s", resp.status_code, resp.content)
-            data = resp.json()
 
-            # handle error
-            if resp.status_code != 200:
-                status_code = resp.status_code
-                logger.error("When sending bot message, we got status %i with message: %s",
-                                   status_code, data)
-                if resp.status_code == 403:
-                    if "description" in data:
-                        if "bot was blocked by the user" in data["description"]:
-                            raise BotBlockedException("User %i blocked the bot" % chat_id)
-                        if "user is deactivated" in data["description"]:
-                            raise UserDeactivatedException("User %i has been deactivated" % chat_id)
+        apprise_urls = []
+        for chat_id in self.receiver_ids:
+            apprise_urls.append(f"tgram://{self.bot_token}/{chat_id}")
+
+        SenderApprise.send(message, apprise_urls)
+        

--- a/flathunter/web_hunter.py
+++ b/flathunter/web_hunter.py
@@ -3,7 +3,7 @@ from flathunter.logging import logger
 from flathunter.hunter import Hunter
 from flathunter.filter import Filter
 from flathunter.processor import ProcessorChain
-from flathunter.exceptions import BotBlockedException, UserDeactivatedException
+from flathunter.exceptions import NotificationException
 
 class WebHunter(Hunter):
     """Flathunter implementation for website. Designed to hunt all exposes from
@@ -41,14 +41,11 @@ class WebHunter(Hunter):
                                                 .build()
                 for message in processor_chain.process(new_exposes):
                     logger.debug("Sent expose %d to user %d", message['id'], user_id)
-            except BotBlockedException:
-                logger.warn("Bot has been blocked by user %d - updating settings", user_id)
+            except NotificationException:
+                logger.warn("Unable to send all notifications to %d - updating settings", user_id)
                 settings["mute_notifications"] = True
                 self.id_watch.save_settings_for_user(user_id, settings)
-            except UserDeactivatedException:
-                logger.warn("User %d has deactivated their telegram account - updating settings", user_id)
-                settings["mute_notifications"] = True
-                self.id_watch.save_settings_for_user(user_id, settings)
+
 
         self.id_watch.update_last_run_time()
         return list(new_exposes)


### PR DESCRIPTION
Make telegram use apprise instead of requests.

The exceptions that the Telegram sender was using have been substituted with a general NotificationException, does it make sense to you? I do not think that it is possible to differentiate between the two exceptions using Apprise.

The testing of the sender is not done.

With regard to Mattermost Apprise does support it ([see here](https://github.com/caronc/apprise/wiki/Notify_mattermost)) but extracting the needed information from the webhook URL must be done carefully to not break compatibility. Unfortunately, I have never used Mattermost so I do not know how the webhook URLs may be structured.