### PR TITLE
Add support for running test suite with captcha solving

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,23 @@
 name: Tests
 
+#############################
+# Start the job on all push #
+#############################
 on:
   push:
-    branches:
-    - master
+    branches-ignore:
+      - 'main'
   pull_request:
 
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    environment: test
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +25,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -30,6 +37,10 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: coverage run
+        env:
+          FLATHUNTER_HEADLESS_BROWSER: true
+          FLATHUNTER_2CAPTCHA_KEY: ${{ secrets.TWOCAPTCHA_API_KEY }}
+          WDM_LOCAL: 1
       - name: Run codecov
         if: ${{ success() }}
         run: codecov

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ celerybeat-schedule
 
 # dotenv
 .env
+.env.*
 
 # virtualenv
 venv/

--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -181,7 +181,7 @@ Preis: {price}
         return self.DEFAULT_MESSAGE_FORMAT
 
     def notifiers(self):
-        return self._read_yaml_path('notifiers', None)
+        return self._read_yaml_path('notifiers', [])
 
     def telegram_bot_token(self):
         return self._read_yaml_path('telegram.bot_token', None)

--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -53,8 +53,7 @@ class Env:
     FLATHUNTER_MATTERMOST_WEBHOOK_URL = _read_env("FLATHUNTER_MATTERMOST_WEBHOOK_URL")
 
 
-class Config:
-    """Class to represent flathunter configuration"""
+class YamlConfig:
 
     DEFAULT_MESSAGE_FORMAT = """{title}
 Zimmer: {rooms}
@@ -63,22 +62,8 @@ Preis: {price}
 
 {url}"""
 
-    def __init__(self, filename=None, string=None):
-        self.useEnvironment = True
-        if string is not None:
-            self.config = yaml.safe_load(string)
-            self.useEnvironment = False
-        else:
-            if filename is None and Env.FLATHUNTER_TARGET_URLS is None:
-                raise Exception("Config file loaction must be specified, or FLATHUNTER_TARGET_URLS must be set")
-            if filename is not None:
-                logger.info("Using config path %s", filename)
-                if not os.path.exists(filename):
-                    raise Exception("No config file found at location %s")
-                with open(filename, encoding="utf-8") as file:
-                    self.config = yaml.safe_load(file)
-            else:
-                self.config = {}
+    def __init__(self, config={}):
+        self.config = config
         self.__searchers__ = []
         self.check_deprecated()
 
@@ -131,15 +116,6 @@ Preis: {price}
             parts = parts[1:]
         return config.get(parts[0], default_value)
 
-    def database_location(self):
-        """Return the location of the database folder"""
-        config_database_location = self._read_yaml_path('database_location')
-        if config_database_location is not None:
-            return config_database_location
-        if self.useEnvironment and Env.FLATHUNTER_DATABASE_LOCATION is not None:
-            return Env.FLATHUNTER_DATABASE_LOCATION
-        return os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/..")
-
     def set_searchers(self, searchers):
         """Update the active search plugins"""
         self.__searchers__ = searchers
@@ -154,46 +130,6 @@ Preis: {price}
         builder.read_config(self.config)
         return builder.build()
 
-    def target_urls(self):
-        if self.useEnvironment and Env.FLATHUNTER_TARGET_URLS is not None:
-            return Env.FLATHUNTER_TARGET_URLS.split(';')
-        return self._read_yaml_path('urls', [])
-
-    def verbose_logging(self):
-        if self.useEnvironment and Env.FLATHUNTER_VERBOSE_LOG is not None:
-            return True
-        return self._read_yaml_path('verbose') is not None
-
-    def loop_is_active(self):
-        if self.useEnvironment and Env.FLATHUNTER_LOOP_PERIOD_SECONDS is not None:
-            return True
-        return self._read_yaml_path('loop.active', False)
-
-    def loop_period_seconds(self):
-        if self.useEnvironment and Env.FLATHUNTER_LOOP_PERIOD_SECONDS is not None:
-            return int(Env.FLATHUNTER_LOOP_PERIOD_SECONDS)
-        return self._read_yaml_path('loop.sleeping_time', 60 * 10)
-
-    def has_website_config(self):
-        if self.useEnvironment and Env.FLATHUNTER_WEBSITE_SESSION_KEY is not None:
-            return True
-        return 'website' in self.config
-
-    def website_session_key(self):
-        if self.useEnvironment and Env.FLATHUNTER_WEBSITE_SESSION_KEY is not None:
-            return Env.FLATHUNTER_WEBSITE_SESSION_KEY
-        return self._read_yaml_path('website.session_key', None)
-
-    def website_domain(self):
-        if self.useEnvironment and Env.FLATHUNTER_WEBSITE_DOMAIN is not None:
-            return Env.FLATHUNTER_WEBSITE_DOMAIN
-        return self._read_yaml_path('website.domain', None)
-
-    def website_bot_name(self):
-        if self.useEnvironment and Env.FLATHUNTER_WEBSITE_BOT_NAME is not None:
-            return Env.FLATHUNTER_WEBSITE_BOT_NAME
-        return self._read_yaml_path('website.bot_name', None)
-
     def captcha_enabled(self):
         """Check if captcha is configured"""
         return self._get_captcha_solver() is not None
@@ -204,60 +140,75 @@ Preis: {price}
     def get_captcha_afterlogin_string(self):
         return self._read_yaml_path('captcha.afterlogin_string', '')
 
+    def database_location(self):
+        """Return the location of the database folder"""
+        config_database_location = self._read_yaml_path('database_location')
+        if config_database_location is not None:
+            return config_database_location
+        return os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/..")
+
+    def target_urls(self):
+        return self._read_yaml_path('urls', [])
+
+    def verbose_logging(self):
+        return self._read_yaml_path('verbose') is not None
+
+    def loop_is_active(self):
+        return self._read_yaml_path('loop.active', False)
+
+    def loop_period_seconds(self):
+        return self._read_yaml_path('loop.sleeping_time', 60 * 10)
+
+    def has_website_config(self):
+        return 'website' in self.config
+
+    def website_session_key(self):
+        return self._read_yaml_path('website.session_key', None)
+
+    def website_domain(self):
+        return self._read_yaml_path('website.domain', None)
+
+    def website_bot_name(self):
+        return self._read_yaml_path('website.bot_name', None)
+
     def google_cloud_project_id(self):
-        if self.useEnvironment and Env.FLATHUNTER_GOOGLE_CLOUD_PROJECT_ID is not None:
-            return Env.FLATHUNTER_GOOGLE_CLOUD_PROJECT_ID
         return self._read_yaml_path('google_cloud_project_id', None)
 
     def message_format(self):
-        if self.useEnvironment and Env.FLATHUNTER_MESSAGE_FORMAT is not None:
-            return '\n'.join(Env.FLATHUNTER_MESSAGE_FORMAT.split('#CR#'))
         config_format = self._read_yaml_path('message', None)
         if config_format is not None:
             return config_format
         return self.DEFAULT_MESSAGE_FORMAT
 
     def notifiers(self):
-        if self.useEnvironment and Env.FLATHUNTER_NOTIFIERS is not None:
-            return Env.FLATHUNTER_NOTIFIERS.split(",")
         return self._read_yaml_path('notifiers', None)
 
     def telegram_bot_token(self):
-        if self.useEnvironment and Env.FLATHUNTER_TELEGRAM_BOT_TOKEN is not None:
-            return Env.FLATHUNTER_TELEGRAM_BOT_TOKEN
         return self._read_yaml_path('telegram.bot_token', None)
 
     def telegram_notify_with_images(self) -> bool:
         flag = str(self._read_yaml_path("telegram.notify_with_images", 'false'))
-
-        if self.useEnvironment and Env.FLATHUNTER_TELEGRAM_BOT_NOTIFY_WITH_IMAGES is not None:
-            flag = str(Env.FLATHUNTER_TELEGRAM_BOT_NOTIFY_WITH_IMAGES)
-
         return flag.lower() == 'true'
 
     def telegram_receiver_ids(self):
-        if self.useEnvironment and Env.FLATHUNTER_TELEGRAM_RECEIVER_IDS is not None:
-            return [ int(x) for x in Env.FLATHUNTER_TELEGRAM_RECEIVER_IDS.split(",") ]
         return self._read_yaml_path('telegram.receiver_ids') or []
 
     def mattermost_webhook_url(self):
-        if self.useEnvironment and Env.FLATHUNTER_MATTERMOST_WEBHOOK_URL is not None:
-            return Env.FLATHUNTER_MATTERMOST_WEBHOOK_URL
         return self._read_yaml_path('mattermost.webhook_url', None)
+
+    def _get_imagetyperz_token(self):
+        return self._read_yaml_path("captcha.imagetyperz.token", "")
+
+    def _get_twocaptcha_key(self):
+        return self._read_yaml_path("captcha.2captcha.api_key", "")
 
     def _get_captcha_solver(self) -> Optional[CaptchaSolver]:
         """Get configured captcha solver"""
-        if self.useEnvironment and Env.FLATHUNTER_IMAGETYPERZ_TOKEN is not None:
-            imagetyperz_token = Env.FLATHUNTER_IMAGETYPERZ_TOKEN
-        else:
-            imagetyperz_token = self._read_yaml_path("captcha.imagetyperz.token", "")
+        imagetyperz_token = self._get_imagetyperz_token()
         if imagetyperz_token:
             return ImageTyperzSolver(imagetyperz_token)
 
-        if self.useEnvironment and Env.FLATHUNTER_2CAPTCHA_KEY is not None:
-            twocaptcha_api_key = Env.FLATHUNTER_2CAPTCHA_KEY
-        else:
-            twocaptcha_api_key = self._read_yaml_path("captcha.2captcha.api_key", "")
+        twocaptcha_api_key = self._get_twocaptcha_key()
         if twocaptcha_api_key:
             return TwoCaptchaSolver(twocaptcha_api_key)
 
@@ -270,7 +221,26 @@ Preis: {price}
         raise Exception("No captcha solver configured properly.")
 
     def captcha_driver_arguments(self):
-        if self.useEnvironment and Env.FLATHUNTER_HEADLESS_BROWSER is not None:
+       return self._read_yaml_path('captcha.driver_arguments', [])
+
+    def use_proxy(self):
+        """Check if proxy is configured"""
+        return "use_proxy_list" in self.config and self.config["use_proxy_list"]
+
+class CaptchaEnvironmentConfig():
+
+    def _get_imagetyperz_token(self):
+        if Env.FLATHUNTER_IMAGETYPERZ_TOKEN is not None:
+            return Env.FLATHUNTER_IMAGETYPERZ_TOKEN
+        return super()._get_imagetyperz_token()
+
+    def _get_twocaptcha_key(self):
+        if Env.FLATHUNTER_2CAPTCHA_KEY is not None:
+            return Env.FLATHUNTER_2CAPTCHA_KEY
+        return super()._get_twocaptcha_key()
+
+    def captcha_driver_arguments(self):
+        if Env.FLATHUNTER_HEADLESS_BROWSER is not None:
             return [
                 "--no-sandbox",
                 "--headless",
@@ -279,8 +249,102 @@ Preis: {price}
                 "--disable-dev-shm-usage",
                 "window-size=1024,768"
             ]
-        return self._read_yaml_path('captcha.driver_arguments', [])
+        return super().captcha_driver_arguments()
 
-    def use_proxy(self):
-        """Check if proxy is configured"""
-        return "use_proxy_list" in self.config and self.config["use_proxy_list"]
+class Config(CaptchaEnvironmentConfig,YamlConfig):
+    """Class to represent flathunter configuration"""
+
+    def __init__(self, filename=None):
+        if filename is None and Env.FLATHUNTER_TARGET_URLS is None:
+            raise Exception("Config file loaction must be specified, or FLATHUNTER_TARGET_URLS must be set")
+        if filename is not None:
+            logger.info("Using config path %s", filename)
+            if not os.path.exists(filename):
+                raise Exception("No config file found at location %s")
+            with open(filename, encoding="utf-8") as file:
+                config = yaml.safe_load(file)
+        else:
+            config = {}
+        super().__init__(config)
+
+    def database_location(self):
+        """Return the location of the database folder"""
+        if Env.FLATHUNTER_DATABASE_LOCATION is not None:
+            return Env.FLATHUNTER_DATABASE_LOCATION
+        return super().database_location()
+
+    def target_urls(self):
+        if Env.FLATHUNTER_TARGET_URLS is not None:
+            return Env.FLATHUNTER_TARGET_URLS.split(';')
+        return super().target_urls()
+
+    def verbose_logging(self):
+        if Env.FLATHUNTER_VERBOSE_LOG is not None:
+            return True
+        return super().verbose_logging()
+
+    def loop_is_active(self):
+        if Env.FLATHUNTER_LOOP_PERIOD_SECONDS is not None:
+            return True
+        return super().loop_is_active()
+
+    def loop_period_seconds(self):
+        if Env.FLATHUNTER_LOOP_PERIOD_SECONDS is not None:
+            return int(Env.FLATHUNTER_LOOP_PERIOD_SECONDS)
+        return super().loop_period_seconds()
+
+    def has_website_config(self):
+        if Env.FLATHUNTER_WEBSITE_SESSION_KEY is not None:
+            return True
+        return super().has_website_config()
+
+    def website_session_key(self):
+        if Env.FLATHUNTER_WEBSITE_SESSION_KEY is not None:
+            return Env.FLATHUNTER_WEBSITE_SESSION_KEY
+        return super().website_session_key()
+
+    def website_domain(self):
+        if Env.FLATHUNTER_WEBSITE_DOMAIN is not None:
+            return Env.FLATHUNTER_WEBSITE_DOMAIN
+        return super().website_domain()
+
+    def website_bot_name(self):
+        if Env.FLATHUNTER_WEBSITE_BOT_NAME is not None:
+            return Env.FLATHUNTER_WEBSITE_BOT_NAME
+        return super().website_bot_name()
+
+    def google_cloud_project_id(self):
+        if Env.FLATHUNTER_GOOGLE_CLOUD_PROJECT_ID is not None:
+            return Env.FLATHUNTER_GOOGLE_CLOUD_PROJECT_ID
+        return super().google_cloud_project_id()
+
+    def message_format(self):
+        if Env.FLATHUNTER_MESSAGE_FORMAT is not None:
+            return '\n'.join(Env.FLATHUNTER_MESSAGE_FORMAT.split('#CR#'))
+        return super().message_format()
+
+    def notifiers(self):
+        if Env.FLATHUNTER_NOTIFIERS is not None:
+            return Env.FLATHUNTER_NOTIFIERS.split(",")
+        return super().notifiers()
+
+    def telegram_bot_token(self):
+        if Env.FLATHUNTER_TELEGRAM_BOT_TOKEN is not None:
+            return Env.FLATHUNTER_TELEGRAM_BOT_TOKEN
+        return super().telegram_bot_token()
+
+    def telegram_notify_with_images(self) -> bool:
+        if Env.FLATHUNTER_TELEGRAM_BOT_NOTIFY_WITH_IMAGES is not None:
+            return str(Env.FLATHUNTER_TELEGRAM_BOT_NOTIFY_WITH_IMAGES) == 'true'
+        return super().telegram_notify_with_images()
+
+    def telegram_receiver_ids(self):
+        if Env.FLATHUNTER_TELEGRAM_RECEIVER_IDS is not None:
+            return [ int(x) for x in Env.FLATHUNTER_TELEGRAM_RECEIVER_IDS.split(",") ]
+        return super().telegram_receiver_ids()
+
+    def mattermost_webhook_url(self):
+        if Env.FLATHUNTER_MATTERMOST_WEBHOOK_URL is not None:
+            return Env.FLATHUNTER_MATTERMOST_WEBHOOK_URL
+        return super().mattermost_webhook_url()
+

--- a/flathunter/hunter.py
+++ b/flathunter/hunter.py
@@ -4,7 +4,7 @@ from itertools import chain
 import requests
 
 from flathunter.logging import logger
-from flathunter.config import Config
+from flathunter.config import YamlConfig
 from flathunter.filter import Filter
 from flathunter.processor import ProcessorChain
 from flathunter.captcha.captcha_solver import CaptchaUnsolvableError
@@ -12,9 +12,9 @@ from flathunter.captcha.captcha_solver import CaptchaUnsolvableError
 class Hunter:
     """Basic methods for crawling and processing / filtering exposes"""
 
-    def __init__(self, config: Config, id_watch):
+    def __init__(self, config: YamlConfig, id_watch):
         self.config = config
-        if not isinstance(self.config, Config):
+        if not isinstance(self.config, YamlConfig):
             raise Exception("Invalid config for hunter - should be a 'Config' object")
         self.id_watch = id_watch
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,8 @@ import unittest
 import tempfile
 import os.path
 import os
-from flathunter.config import Config 
+from flathunter.config import Config
+from utils.config import StringConfig
 
 class ConfigTest(unittest.TestCase):
 
@@ -63,25 +64,25 @@ filters:
        self.assertTrue(len(config.get('urls')) > 0, "Expected URLs in config file")
 
     def test_loads_config_from_string(self):
-       config = Config(string=self.EMPTY_FILTERS_CONFIG)
+       config = StringConfig(string=self.EMPTY_FILTERS_CONFIG)
        self.assertIsNotNone(config)
        my_filter = config.get_filter()
        self.assertIsNotNone(my_filter)
 
     def test_loads_legacy_config_from_string(self):
-       config = Config(string=self.LEGACY_FILTERS_CONFIG)
+       config = StringConfig(string=self.LEGACY_FILTERS_CONFIG)
        self.assertIsNotNone(config)
        my_filter = config.get_filter()
        self.assertIsNotNone(my_filter)
        self.assertTrue(len(my_filter.filters) > 0)
 
     def test_loads_filters_config_from_string(self):
-       config = Config(string=self.FILTERS_CONFIG)
+       config = StringConfig(string=self.FILTERS_CONFIG)
        self.assertIsNotNone(config)
        my_filter = config.get_filter()
        self.assertIsNotNone(my_filter)
 
     def test_defaults_fields(self):
-       config = Config(string=self.FILTERS_CONFIG)
+       config = StringConfig(string=self.FILTERS_CONFIG)
        self.assertIsNotNone(config)
        self.assertEqual(config.database_location(), os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/.."))

--- a/test/test_crawl_ebaykleinanzeigen.py
+++ b/test/test_crawl_ebaykleinanzeigen.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flathunter.crawl_ebaykleinanzeigen import CrawlEbayKleinanzeigen
-from flathunter.config import Config
+from utils.config import StringConfig
 
 DUMMY_CONFIG = """
 urls:
@@ -12,7 +12,7 @@ TEST_URL = 'https://www.ebay-kleinanzeigen.de/s-wohnung-mieten/berlin/preis:1000
 
 @pytest.fixture
 def crawler():
-    return CrawlEbayKleinanzeigen(Config(string=DUMMY_CONFIG))
+    return CrawlEbayKleinanzeigen(StringConfig(string=DUMMY_CONFIG))
 
 def test_crawler(crawler):
     soup = crawler.get_page(TEST_URL)

--- a/test/test_crawl_immobilienscout.py
+++ b/test/test_crawl_immobilienscout.py
@@ -29,7 +29,7 @@ def test_parse_exposes_from_json(crawler):
 def test_crawl_works(crawler):
     if not test_config.captcha_enabled():
         pytest.skip("Captcha solving is not enabled - skipping immoscout tests. Setup captcha solving")
-    soup = crawler.get_page(TEST_URL, page_no=1)
+    soup = crawler.get_page(TEST_URL, crawler.driver, page_no=1)
     assert soup is not None
     entries = crawler.extract_data(soup)
     assert entries is not None
@@ -42,7 +42,7 @@ def test_crawl_works(crawler):
 def test_process_expose_fetches_details(crawler):
     if not test_config.captcha_enabled():
         pytest.skip("Captcha solving is not enabled - skipping immoscout tests. Setup captcha solving")
-    soup = crawler.get_page(TEST_URL, page_no=1)
+    soup = crawler.get_page(TEST_URL, crawler.driver, page_no=1)
     assert soup is not None
     entries = crawler.extract_data(soup)
     assert entries is not None

--- a/test/test_crawl_immobilienscout.py
+++ b/test/test_crawl_immobilienscout.py
@@ -1,9 +1,10 @@
 import pytest
 import json
 import os
+import sys
 
 from flathunter.crawl_immobilienscout import CrawlImmobilienscout
-from flathunter.config import Config
+from utils.config import StringConfigWithCaptchas
 
 DUMMY_CONFIG = """
 urls:
@@ -13,9 +14,11 @@ urls:
 
 TEST_URL = 'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mieten?numberofrooms=2.0-&price=-1500.0&livingspace=70.0-&sorting=2&pagenumber=1'
 
+test_config = StringConfigWithCaptchas(string=DUMMY_CONFIG)
+
 @pytest.fixture
 def crawler():
-    return CrawlImmobilienscout(Config(string=DUMMY_CONFIG))
+    return CrawlImmobilienscout(test_config)
 
 def test_parse_exposes_from_json(crawler):
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures", "immo-scout-IS24-object.json")) as fixture:
@@ -24,6 +27,8 @@ def test_parse_exposes_from_json(crawler):
     assert len(entries) > 0
 
 def test_crawl_works(crawler):
+    if not test_config.captcha_enabled():
+        pytest.skip("Captcha solving is not enabled - skipping immoscout tests. Setup captcha solving")
     soup = crawler.get_page(TEST_URL, page_no=1)
     assert soup is not None
     entries = crawler.extract_data(soup)
@@ -35,6 +40,8 @@ def test_crawl_works(crawler):
         assert entries[0][attr] is not None
 
 def test_process_expose_fetches_details(crawler):
+    if not test_config.captcha_enabled():
+        pytest.skip("Captcha solving is not enabled - skipping immoscout tests. Setup captcha solving")
     soup = crawler.get_page(TEST_URL, page_no=1)
     assert soup is not None
     entries = crawler.extract_data(soup)

--- a/test/test_crawl_immowelt.py
+++ b/test/test_crawl_immowelt.py
@@ -2,7 +2,7 @@ import pytest
 
 from flathunter.crawl_immowelt import CrawlImmowelt
 from test_util import count
-from flathunter.config import Config
+from utils.config import StringConfig
 
 DUMMY_CONFIG = """
 urls:
@@ -13,7 +13,7 @@ TEST_URL = 'https://www.immowelt.de/liste/berlin/wohnungen/mieten?roomi=2&prima=
 
 @pytest.fixture
 def crawler():
-    return CrawlImmowelt(Config(string=DUMMY_CONFIG))
+    return CrawlImmowelt(StringConfig(string=DUMMY_CONFIG))
 
 
 def test_crawler(crawler):

--- a/test/test_crawl_immowelt.py
+++ b/test/test_crawl_immowelt.py
@@ -24,7 +24,7 @@ def test_crawler(crawler):
     assert len(entries) > 0
     assert entries[0]['id']
     assert entries[0]['url'].startswith("https://www.immowelt.de/expose")
-    for attr in [ 'title', 'price', 'size', 'rooms', 'address', 'image' ]:
+    for attr in [ 'title', 'price', 'size', 'rooms', 'address' ]:
         assert entries[0][attr] is not None
 
 def test_dont_crawl_other_urls(crawler):

--- a/test/test_crawl_wggesucht.py
+++ b/test/test_crawl_wggesucht.py
@@ -1,7 +1,7 @@
 import unittest
 from functools import reduce
 from flathunter.crawl_wggesucht import CrawlWgGesucht
-from flathunter.config import Config
+from utils.config import StringConfig
 
 class WgGesuchtCrawlerTest(unittest.TestCase):
 
@@ -11,7 +11,7 @@ class WgGesuchtCrawlerTest(unittest.TestCase):
       - https://www.wg-gesucht.de/wohnungen-in-Munchen.90.2.1.0.html
         """
     def setUp(self):
-        self.crawler = CrawlWgGesucht(Config(string=self.DUMMY_CONFIG))
+        self.crawler = CrawlWgGesucht(StringConfig(string=self.DUMMY_CONFIG))
 
     def test(self):
         soup = self.crawler.get_page(self.TEST_URL)

--- a/test/test_gmaps_duration_processor.py
+++ b/test/test_gmaps_duration_processor.py
@@ -3,10 +3,10 @@ import yaml
 import re
 import requests_mock
 from flathunter.hunter import Hunter
-from flathunter.config import Config
 from flathunter.idmaintainer import IdMaintainer
 from dummy_crawler import DummyCrawler
 from test_util import count
+from utils.config import StringConfig
 
 class GMapsDurationProcessorTest(unittest.TestCase):
 
@@ -36,7 +36,7 @@ durations:
 
     @requests_mock.Mocker()
     def test_resolve_durations(self, m):
-        config = Config(string=self.DUMMY_CONFIG)
+        config = StringConfig(string=self.DUMMY_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         matcher = re.compile('maps.googleapis.com/maps/api/distancematrix/json')

--- a/test/test_googlecloud_idmaintainer.py
+++ b/test/test_googlecloud_idmaintainer.py
@@ -4,12 +4,12 @@ import re
 from mockfirestore import MockFirestore
 
 from flathunter.googlecloud_idmaintainer import GoogleCloudIdMaintainer
-from flathunter.config import Config
 from flathunter.hunter import Hunter
 from flathunter.web_hunter import WebHunter
 from flathunter.filter import Filter
 from dummy_crawler import DummyCrawler
 from test_util import count
+from utils.config import StringConfig
 
 class MockGoogleCloudIdMaintainer(GoogleCloudIdMaintainer):
 
@@ -41,7 +41,7 @@ def test_get_list_run_time_is_updated(id_watch):
     assert time == id_watch.get_last_run_time()
 
 def test_is_processed_works(id_watch):
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     hunter = Hunter(config, id_watch)
     exposes = hunter.hunt_flats()
@@ -50,7 +50,7 @@ def test_is_processed_works(id_watch):
         assert id_watch.is_processed(expose['id'])
 
 def test_exposes_are_saved_to_maintainer(id_watch):
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     hunter = Hunter(config, id_watch)
     exposes = hunter.hunt_flats()
@@ -60,7 +60,7 @@ def test_exposes_are_saved_to_maintainer(id_watch):
     assert count(exposes) < len(saved)
 
 def test_exposes_are_returned_as_dictionaries(id_watch):
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     hunter = Hunter(config, id_watch)
     hunter.hunt_flats()
@@ -71,7 +71,7 @@ def test_exposes_are_returned_as_dictionaries(id_watch):
     assert expose['created_at'] is not None
 
 def test_exposes_are_returned_with_limit(id_watch):
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     hunter = Hunter(config, id_watch)
     hunter.hunt_flats()
@@ -81,7 +81,7 @@ def test_exposes_are_returned_with_limit(id_watch):
     assert expose['title'] is not None
 
 def test_exposes_are_returned_filtered(id_watch):
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     hunter = Hunter(config, id_watch)
     hunter.hunt_flats()
@@ -94,20 +94,20 @@ def test_exposes_are_returned_filtered(id_watch):
 
 def test_filters_for_user_are_saved(id_watch):
     filter = { 'fish': 'cat' }
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     hunter = WebHunter(config, id_watch)
     hunter.set_filters_for_user(123, filter)
     assert hunter.get_filters_for_user(123) == filter
 
 def test_filters_for_user_returns_none_if_none_present(id_watch):
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     hunter = WebHunter(config, id_watch)
     assert hunter.get_filters_for_user(123) == None
     assert hunter.get_filters_for_user(None) == None
 
 def test_all_filters_can_be_loaded(id_watch):
     filter = { 'fish': 'cat' }
-    config = Config(string=CONFIG_WITH_FILTERS)
+    config = StringConfig(string=CONFIG_WITH_FILTERS)
     hunter = WebHunter(config, id_watch)
     hunter.set_filters_for_user(123, filter)
     hunter.set_filters_for_user(124, filter)

--- a/test/test_hunter.py
+++ b/test/test_hunter.py
@@ -3,10 +3,10 @@ import yaml
 import re
 from flathunter.crawl_immowelt import CrawlImmowelt
 from flathunter.hunter import Hunter 
-from flathunter.config import Config
 from flathunter.idmaintainer import IdMaintainer
 from dummy_crawler import DummyCrawler
 from test_util import count
+from utils.config import StringConfig
 
 class HunterTest(unittest.TestCase):
 
@@ -95,8 +95,8 @@ excluded_titles:
 """
 
     def test_hunt_flats(self):
-        config = Config(string=self.DUMMY_CONFIG)
-        config.set_searchers([CrawlImmowelt(Config(string=self.DUMMY_CONFIG))])
+        config = StringConfig(string=self.DUMMY_CONFIG)
+        config.set_searchers([CrawlImmowelt(config)])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
         self.assertTrue(count(exposes) > 0, "Expected to find exposes")
@@ -110,7 +110,7 @@ excluded_titles:
     def test_filter_titles_legacy(self):
         titlewords = [ "wg", "tausch", "flat", "ruhig", "gruen" ]
         filteredwords = [ "wg", "tausch", "wochenendheimfahrer", "pendler", "zwischenmiete" ]
-        config = Config(string=self.FILTER_TITLES_LEGACY_CONFIG)
+        config = StringConfig(string=self.FILTER_TITLES_LEGACY_CONFIG)
         config.set_searchers([DummyCrawler(titlewords)])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -124,7 +124,7 @@ excluded_titles:
     def test_filter_titles(self):
         titlewords = [ "wg", "tausch", "flat", "ruhig", "gruen" ]
         filteredwords = [ "wg", "tausch", "wochenendheimfahrer", "pendler", "zwischenmiete" ]
-        config = Config(string=self.FILTER_TITLES_CONFIG)
+        config = StringConfig(string=self.FILTER_TITLES_CONFIG)
         config.set_searchers([DummyCrawler(titlewords)])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -137,7 +137,7 @@ excluded_titles:
 
     def test_filter_min_price(self):
         min_price = 700
-        config = Config(string=self.FILTER_MIN_PRICE_CONFIG)
+        config = StringConfig(string=self.FILTER_MIN_PRICE_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -150,7 +150,7 @@ excluded_titles:
 
     def test_filter_max_price(self):
         max_price = 1000
-        config = Config(string=self.FILTER_MAX_PRICE_CONFIG)
+        config = StringConfig(string=self.FILTER_MAX_PRICE_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -163,7 +163,7 @@ excluded_titles:
 
     def test_filter_max_size(self):
         max_size = 80
-        config = Config(string=self.FILTER_MAX_SIZE_CONFIG)
+        config = StringConfig(string=self.FILTER_MAX_SIZE_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -176,7 +176,7 @@ excluded_titles:
 
     def test_filter_min_size(self):
         min_size = 80
-        config = Config(string=self.FILTER_MIN_SIZE_CONFIG)
+        config = StringConfig(string=self.FILTER_MIN_SIZE_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -189,7 +189,7 @@ excluded_titles:
 
     def test_filter_max_rooms(self):
         max_rooms = 3
-        config = Config(string=self.FILTER_MAX_ROOMS_CONFIG)
+        config = StringConfig(string=self.FILTER_MAX_ROOMS_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -202,7 +202,7 @@ excluded_titles:
 
     def test_filter_min_rooms(self):
         min_rooms = 2
-        config = Config(string=self.FILTER_MIN_ROOMS_CONFIG)
+        config = StringConfig(string=self.FILTER_MIN_ROOMS_CONFIG)
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()

--- a/test/test_id_maintainer.py
+++ b/test/test_id_maintainer.py
@@ -3,12 +3,12 @@ import datetime
 import re
 
 from flathunter.idmaintainer import IdMaintainer
-from flathunter.config import Config
 from flathunter.hunter import Hunter
 from flathunter.web_hunter import WebHunter
 from flathunter.filter import Filter
 from dummy_crawler import DummyCrawler
 from test_util import count
+from utils.config import StringConfig
 
 class IdMaintainerTest(unittest.TestCase):
 
@@ -43,7 +43,7 @@ filters:
         self.assertEqual(time, self.maintainer.get_last_run_time(), "Expected last run time to be updated")
 
 def test_is_processed_works(mocker):
-    config = Config(string=IdMaintainerTest.DUMMY_CONFIG)
+    config = StringConfig(string=IdMaintainerTest.DUMMY_CONFIG)
     config.set_searchers([DummyCrawler()])
     id_watch = IdMaintainer(":memory:")
     hunter = Hunter(config, id_watch)
@@ -53,7 +53,7 @@ def test_is_processed_works(mocker):
         assert id_watch.is_processed(expose['id'])
 
 def test_ids_are_added_to_maintainer(mocker):
-    config = Config(string=IdMaintainerTest.DUMMY_CONFIG)
+    config = StringConfig(string=IdMaintainerTest.DUMMY_CONFIG)
     config.set_searchers([DummyCrawler()])
     id_watch = IdMaintainer(":memory:")
     spy = mocker.spy(id_watch, "mark_processed")
@@ -63,7 +63,7 @@ def test_ids_are_added_to_maintainer(mocker):
     assert spy.call_count == 24
 
 def test_exposes_are_saved_to_maintainer():
-    config = Config(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
+    config = StringConfig(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     id_watch = IdMaintainer(":memory:")
     hunter = Hunter(config, id_watch)
@@ -74,7 +74,7 @@ def test_exposes_are_saved_to_maintainer():
     assert count(exposes) < len(saved)
 
 def test_exposes_are_returned_as_dictionaries():
-    config = Config(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
+    config = StringConfig(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     id_watch = IdMaintainer(":memory:")
     hunter = Hunter(config, id_watch)
@@ -86,7 +86,7 @@ def test_exposes_are_returned_as_dictionaries():
     assert expose['created_at'] is not None
 
 def test_exposes_are_returned_with_limit():
-    config = Config(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
+    config = StringConfig(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     id_watch = IdMaintainer(":memory:")
     hunter = Hunter(config, id_watch)
@@ -97,7 +97,7 @@ def test_exposes_are_returned_with_limit():
     assert expose['title'] is not None
 
 def test_exposes_are_returned_filtered():
-    config = Config(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
+    config = StringConfig(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
     config.set_searchers([DummyCrawler()])
     id_watch = IdMaintainer(":memory:")
     hunter = Hunter(config, id_watch)
@@ -110,7 +110,7 @@ def test_exposes_are_returned_filtered():
         assert int(re.match(r'\d+', expose['size'])[0]) <= 70
 
 def test_filters_for_user_are_saved():
-    config = Config(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
+    config = StringConfig(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
     id_watch = IdMaintainer(":memory:")
     filter = { 'fish': 'cat' }
     hunter = WebHunter(config, id_watch)
@@ -118,7 +118,7 @@ def test_filters_for_user_are_saved():
     assert hunter.get_filters_for_user(123) == filter
 
 def test_all_filters_can_be_loaded():
-    config = Config(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
+    config = StringConfig(string=IdMaintainerTest.CONFIG_WITH_FILTERS)
     id_watch = IdMaintainer(":memory:")
     filter = { 'fish': 'cat' }
     hunter = WebHunter(config, id_watch)

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -3,11 +3,11 @@ import yaml
 import re
 from flathunter.crawl_immowelt import CrawlImmowelt
 from flathunter.hunter import Hunter
-from flathunter.config import Config
 from flathunter.idmaintainer import IdMaintainer
 from flathunter.processor import ProcessorChain
 from dummy_crawler import DummyCrawler
 from test_util import count
+from utils.config import StringConfig
 
 class ProcessorTest(unittest.TestCase):
 
@@ -22,7 +22,7 @@ google_maps_api:
     """
 
     def test_addresses_are_processed_by_hunter(self):
-        config = Config(string=self.DUMMY_CONFIG)
+        config = StringConfig(string=self.DUMMY_CONFIG)
         config.set_searchers([DummyCrawler(addresses_as_links=True)])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
@@ -32,7 +32,7 @@ google_maps_api:
 
     def test_address_processor(self):
         crawler = DummyCrawler(addresses_as_links=True)
-        config = Config(string=self.DUMMY_CONFIG)
+        config = StringConfig(string=self.DUMMY_CONFIG)
         config.set_searchers([crawler])
         exposes = crawler.get_results("https://www.example.com/search")
         for expose in exposes:

--- a/test/test_sender_mattermost.py
+++ b/test/test_sender_mattermost.py
@@ -3,15 +3,16 @@ import unittest
 import requests_mock
 
 from flathunter.sender_mattermost import SenderMattermost
+from flathunter.config import YamlConfig
 
 
 class SenderMattermostTest(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_send_message(self, m):
-        sender = SenderMattermost({"mattermost": {
-            "webhook_url": "http://example.com/dummy_webhook_url"}})
+        sender = SenderMattermost(YamlConfig({"mattermost": {
+            "webhook_url": "http://example.com/dummy_webhook_url"}}))
 
         m.post('http://example.com/dummy_webhook_url')
-        self.assertEqual(None, sender.send_msg("result"),
+        self.assertEqual(None, sender.notify("result"),
                          "Expected message to be sent")

--- a/test/test_sender_telegram.py
+++ b/test/test_sender_telegram.py
@@ -3,8 +3,8 @@ import unittest
 
 from requests_mock import Mocker
 from utils.request_matcher import RequestCounter
+from utils.config import StringConfig
 
-from flathunter.config import Config
 from flathunter.sender_telegram import SenderTelegram
 
 
@@ -12,7 +12,7 @@ class SenderTelegramTest(unittest.TestCase):
 
     @Mocker()
     def test_send_message(self, m: Mocker):
-        config = Config(string=json.dumps({"telegram": {"bot_token": "dummy_token", "receiver_ids": [123]}}))
+        config = StringConfig(string=json.dumps({"telegram": {"bot_token": "dummy_token", "receiver_ids": [123]}}))
         sender = SenderTelegram(config=config)
 
         mock_response = '''{
@@ -30,13 +30,13 @@ class SenderTelegramTest(unittest.TestCase):
 
     @Mocker()
     def test_send_no_message_if_no_receivers(self, m: Mocker):
-        config = Config(string=json.dumps({"telegram": {"bot_token": "dummy_token", "receiver_ids": None}}))
+        config = StringConfig(string=json.dumps({"telegram": {"bot_token": "dummy_token", "receiver_ids": None}}))
         sender = SenderTelegram(config=config)
         self.assertEqual(None, sender.notify("result"), "Expected no message to be sent")
 
     @Mocker()
     def test_send_message_with_image(self, m: Mocker):
-        c = Config(string=json.dumps(
+        c = StringConfig(string=json.dumps(
             {"telegram": {"bot_token": "dummy_token", "receiver_ids": [1234567], "notify_with_images": "true"}}
         ))
         sender = SenderTelegram(config=c)
@@ -63,7 +63,7 @@ class SenderTelegramTest(unittest.TestCase):
 
     @Mocker()
     def test_images_will_be_chunked(self, m: Mocker):
-        c = Config(string=json.dumps(
+        c = StringConfig(string=json.dumps(
             {"telegram": {"bot_token": "dummy_token", "receiver_ids": [1234567], "notify_with_images": "true"}}
         ))
 

--- a/test/test_statistics_view.py
+++ b/test/test_statistics_view.py
@@ -9,9 +9,9 @@ from flask import session
 from flathunter.web import app
 from flathunter.web_hunter import WebHunter
 from flathunter.idmaintainer import IdMaintainer
-from flathunter.config import Config
 
 from dummy_crawler import DummyCrawler
+from utils.config import StringConfig
 
 DUMMY_CONFIG = """
 telegram:
@@ -27,7 +27,7 @@ urls:
 def hunt_client():
     app.config['TESTING'] = True
     with tempfile.NamedTemporaryFile(mode='w+') as temp_db:
-        config = Config(string=DUMMY_CONFIG)
+        config = StringConfig(string=DUMMY_CONFIG)
         config.set_searchers([DummyCrawler()])
         app.config['HUNTER'] = WebHunter(config, IdMaintainer(temp_db.name))
         app.config['BOT_TOKEN'] = "1234xxx.12345"

--- a/test/utils/config.py
+++ b/test/utils/config.py
@@ -1,0 +1,17 @@
+"""Wrap configuration options as an object"""
+import yaml
+
+from flathunter.config import YamlConfig, CaptchaEnvironmentConfig
+
+class StringConfig(YamlConfig):
+    """Class to represent flathunter configuration for tests"""
+
+    def __init__(self, string=None):
+        if string is not None:
+            config = yaml.safe_load(string)
+        else:
+            config = {}
+        super().__init__(config)
+
+class StringConfigWithCaptchas(CaptchaEnvironmentConfig,StringConfig):
+    """Class to represent flathunter configuration for tests, with captcha support"""


### PR DESCRIPTION
The github runner (and local test runs) fails because the test suite does not support captcha solving - test_crawl_immobilienscout.py always fails.

I've refactored the environment handling and the test suite so that the test suite can be run passing FLATHUNTER_2CATPCHA_API_KEY in the environment. With this set, the tests pass in the runner (and probably for users)

After merge, the environment secrets will have to be added to the flathunter repo - we can use my 2captcha key