### PR TITLE
set GET request header cookie

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -191,3 +191,10 @@ apprise:
 # For websites like idealista.it, there are anti-crawler measures that can be
 # circumvented using proxies.
 # use_proxy_list: True
+
+# If you are having bot detection issues with immobilienscout24,
+# you can set the cookie that you get from your logged in account
+# Go to the immobilienscout24.de website, log in, and then in the developer tools
+# (F12) go to the "Network" tab, then "Cookies" and copy the value of the
+# "reese84" cookie.
+immoscout_cookie: ""

--- a/flathunter/crawl_immobilienscout.py
+++ b/flathunter/crawl_immobilienscout.py
@@ -31,7 +31,8 @@ class CrawlImmobilienscout(Crawler):
         self.driver = None
         self.checkbox = None
         self.afterlogin_string = None
-
+        if "immoscout_cookie" in self.config:
+            self.set_cookie()
         if config.captcha_enabled():
             self.checkbox = config.get_captcha_checkbox()
             self.afterlogin_string = config.get_captcha_afterlogin_string()
@@ -147,13 +148,17 @@ class CrawlImmobilienscout(Crawler):
             'rooms': str(entry.get("numberOfRooms", ''))
         }
 
+    def set_cookie(self):
+        """Sets request header cookie parameter to identify as a logged in user"""
+        self.HEADERS['Cookie'] = f'reese84:${self.config["immoscout_cookie"]}'
+
     def get_page(self, search_url, driver=None, page_no=None):
         """Applies a page number to a formatted search URL and fetches the exposes at that page"""
         return self.get_soup_from_url(
             search_url.format(page_no),
             driver=driver,
             checkbox=self.checkbox,
-            afterlogin_string=self.afterlogin_string
+            afterlogin_string=self.afterlogin_string,
         )
 
     def get_expose_details(self, expose):


### PR DESCRIPTION
This PR let's user to set GET request header cookie enabling with enables them to surpasss the bot detection script by immoscout24 #302. The cookie should be copied from a logged in session of a user. Once the cookie is compromised a new one should be created.