### PR TITLE
use float instead of int for price per sqm

### DIFF
--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -524,5 +524,5 @@ class Config(CaptchaEnvironmentConfig): # pylint: disable=too-many-public-method
 
     def max_price_per_square(self):
         if Env.FLATHUNTER_FILTER_MAX_PRICE_PER_SQUARE is not None:
-            return int(Env.FLATHUNTER_FILTER_MAX_PRICE_PER_SQUARE)
+            return float(Env.FLATHUNTER_FILTER_MAX_PRICE_PER_SQUARE)
         return super().max_price_per_square()


### PR DESCRIPTION
makes it easier to use float values for pps (like 19.5)