### PR TITLE
fix #383

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Currently available messaging services are [Telegram](https://telegram.org/), [M
 
 ## Background
 
-There are at least four different rental property marketplace sites that are widely used in Germany - [ImmoScout24](https://www.immobilienscout24.de/), [Immowelt](https://www.immowelt.de/), [WG-Gesucht](https://www.wg-gesucht.de/) and [eBay Kleinanzeigen](https://www.ebay-kleinanzeigen.de/). Most people end up searching through listings on all four sites on an almost daily basis during their rental search.
+There are at least four different rental property marketplace sites that are widely used in Germany - [ImmoScout24](https://www.immobilienscout24.de/), [Immowelt](https://www.immowelt.de/), [WG-Gesucht](https://www.wg-gesucht.de/) and [eBay Kleinanzeigen](https://www.kleinanzeigen.de/). Most people end up searching through listings on all four sites on an almost daily basis during their rental search.
 In Italy on the other hand, [idealista](https://www.idealista.it), [Subito](https://www.subito.it) and [Immobiliare.it](https://www.immobiliare.it) are very common for real-estate hunting.
 
 With ```Flathunter```, instead of visiting the same pages on the same  sites every day, you can set the system up to scan every site, filtering by your search criteria, and notify you when new rental property becomes available that meets your criteria.

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -17,7 +17,7 @@ loop:
 
 # List the URLs containing your filter properties below.
 # Currently supported services: www.immobilienscout24.de,
-# www.immowelt.de, www.wg-gesucht.de, and www.ebay-kleinanzeigen.de.
+# www.immowelt.de, www.wg-gesucht.de, and www.kleinanzeigen.de.
 # List the URLs in the following format:
 # urls:
 # 	- https://www.immobilienscout24.de/Suche/...

--- a/config_wizard.py
+++ b/config_wizard.py
@@ -72,7 +72,7 @@ def gather_urls(config: YamlConfig) -> List[str]:
         clear()
         print("Enter URLs for Scraping\n")
         print("Flathunter scrapes property portals by fetching content from search URLs\n"
-            "on the websites. Visit ImmoScout, ImmoWelt, eBay-Kleinanzeigen or WG-Gesucht,\n"
+            "on the websites. Visit ImmoScout, ImmoWelt, Kleinanzeigen or WG-Gesucht,\n"
             "make a search for the flat that you are looking for (e.g. pick a city), and\n"
             "copy the URL here. You can add as many URLs as you like.\n\n")
         if len(urls) > 0:

--- a/flathunter/crawler/ebaykleinanzeigen.py
+++ b/flathunter/crawler/ebaykleinanzeigen.py
@@ -10,7 +10,7 @@ from flathunter.abstract_crawler import Crawler
 class CrawlEbayKleinanzeigen(Crawler):
     """Implementation of Crawler interface for Ebay Kleinanzeigen"""
 
-    URL_PATTERN = re.compile(r'https://www\.ebay-kleinanzeigen\.de')
+    URL_PATTERN = re.compile(r'https://www\.kleinanzeigen\.de')
     MONTHS = {
         "Januar": "01",
         "Februar": "02",

--- a/flathunter/crawler/ebaykleinanzeigen.py
+++ b/flathunter/crawler/ebaykleinanzeigen.py
@@ -92,7 +92,7 @@ class CrawlEbayKleinanzeigen(Crawler):
             details = {
                 'id': int(expose_ids[idx].get("data-adid")),
                 'image': image,
-                'url': ("https://www.ebay-kleinanzeigen.de" + title_el.get("href")),
+                'url': ("https://www.kleinanzeigen.de" + title_el.get("href")),
                 'title': title_el.text.strip(),
                 'price': price,
                 'size': size,

--- a/test/test_crawl_ebaykleinanzeigen.py
+++ b/test/test_crawl_ebaykleinanzeigen.py
@@ -5,10 +5,10 @@ from test.utils.config import StringConfig
 
 DUMMY_CONFIG = """
 urls:
-  - https://www.ebay-kleinanzeigen.de/s-wohnung-mieten/muenchen/anbieter:privat/anzeige:angebote/preis:600:1000
+  - https://www.kleinanzeigen.de/s-wohnung-mieten/muenchen/anbieter:privat/anzeige:angebote/preis:600:1000
     """
 
-TEST_URL = 'https://www.ebay-kleinanzeigen.de/s-wohnung-mieten/berlin/preis:1000:1500/c203l3331+wohnung_mieten.qm_d:70,+wohnung_mieten.zimmer_d:2'
+TEST_URL = 'https://www.kleinanzeigen.de/s-wohnung-mieten/berlin/preis:1000:1500/c203l3331+wohnung_mieten.qm_d:70,+wohnung_mieten.zimmer_d:2'
 
 @pytest.fixture
 def crawler():
@@ -21,7 +21,7 @@ def test_crawler(crawler):
     assert entries is not None
     assert len(entries) > 0
     assert entries[0]['id'] > 0
-    assert entries[0]['url'].startswith("https://www.ebay-kleinanzeigen.de/s-anzeige")
+    assert entries[0]['url'].startswith("https://www.kleinanzeigen.de/s-anzeige")
     for attr in [ 'title', 'price', 'size', 'rooms', 'address' ]:
         assert entries[0][attr]
 


### PR DESCRIPTION
ebay-kleinanzeigen.de changed to kleinanzeigen.de

I tested it for my search and it seems to work just fine. 
Maybe with the official launch there will be some more changes to the website but for now its works. 