### PR TITLE
Improved bot detection by avoiding API request

### DIFF
--- a/flathunter/abstract_crawler.py
+++ b/flathunter/abstract_crawler.py
@@ -69,11 +69,6 @@ class Crawler(ABC):
         afterlogin_string: Optional[str]=None) -> BeautifulSoup:
         """Creates a Soup object from the HTML at the provided URL"""
 
-        self.rotate_user_agent()
-        resp = requests.get(url, headers=self.HEADERS, timeout=30)
-
-        if resp.status_code not in (200, 405):
-            logger.error("Got response (%i): %s", resp.status_code, resp.content)
         if self.config.use_proxy():
             return self.get_soup_with_proxy(url)
         if driver is not None:
@@ -83,6 +78,12 @@ class Crawler(ABC):
             elif re.search("g-recaptcha", driver.page_source):
                 self.resolve_recaptcha(driver, checkbox, afterlogin_string or "")
             return BeautifulSoup(driver.page_source, 'html.parser')
+        
+        self.rotate_user_agent()
+        resp = requests.get(url, headers=self.HEADERS, timeout=30)
+        if resp.status_code not in (200, 405):
+            logger.error("Got response (%i): %s", resp.status_code, resp.content)
+
         return BeautifulSoup(resp.content, 'html.parser')
 
     def get_soup_with_proxy(self, url) -> BeautifulSoup:

--- a/flathunter/abstract_crawler.py
+++ b/flathunter/abstract_crawler.py
@@ -78,7 +78,7 @@ class Crawler(ABC):
             elif re.search("g-recaptcha", driver.page_source):
                 self.resolve_recaptcha(driver, checkbox, afterlogin_string or "")
             return BeautifulSoup(driver.page_source, 'html.parser')
-        
+
         self.rotate_user_agent()
         resp = requests.get(url, headers=self.HEADERS, timeout=30)
         if resp.status_code not in (200, 405):


### PR DESCRIPTION
I found an API request in the project that doesn't really do anything except printing a warning. In case of a driver present, all of the subsequent page evaluation and captcha solving is done without the need for this request. To minimize the API requests considering bot detection I moved it so that it will only be executed when no driver is present (i.e. when the function didn't escape already).