### PR TITLE
Update installation guide: create /home for user flathunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ git clone https://github.com/flathunters/flathunter.git
 ```
 add a new User and configure the permissions
 ```sh
-$ useradd flathunter
+$ useradd -m flathunter
 $ chown flathunter:flathunter -R flathunter/
 ```
 Next install pipenv for the new user


### PR DESCRIPTION
Update installation instructions to prevent this permission error:

```bash
ERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/home/flathunter'
Check the permissions.
```
because `useradd flathunter` does not create a `/home/flathunter` folder without the `-m` flag