### PR TITLE
:recycle: rename Crawler

### DIFF
--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -9,14 +9,14 @@ from dotenv import load_dotenv
 from flathunter.captcha.captcha_solver import CaptchaSolver
 from flathunter.captcha.imagetyperz_solver import ImageTyperzSolver
 from flathunter.captcha.twocaptcha_solver import TwoCaptchaSolver
-from flathunter.crawler.ebaykleinanzeigen import CrawlEbayKleinanzeigen
-from flathunter.crawler.idealista import CrawlIdealista
-from flathunter.crawler.immobiliare import CrawlImmobiliare
-from flathunter.crawler.immobilienscout import CrawlImmobilienscout
-from flathunter.crawler.immowelt import CrawlImmowelt
-from flathunter.crawler.meinestadt import CrawlMeineStadt
-from flathunter.crawler.wggesucht import CrawlWgGesucht
-from flathunter.crawler.subito import CrawlSubito
+from flathunter.crawler.ebaykleinanzeigen import EbayKleinanzeigen
+from flathunter.crawler.idealista import Idealista
+from flathunter.crawler.immobiliare import Immobiliare
+from flathunter.crawler.immobilienscout import Immobilienscout
+from flathunter.crawler.immowelt import Immowelt
+from flathunter.crawler.meinestadt import MeineStadt
+from flathunter.crawler.wggesucht import WgGesucht
+from flathunter.crawler.subito import Subito
 from flathunter.filter import Filter
 from flathunter.logging import logger
 from flathunter.exceptions import ConfigException
@@ -117,14 +117,14 @@ Preis: {price}
     def init_searchers(self):
         """Initialize search plugins"""
         self.__searchers__ = [
-            CrawlImmobilienscout(self),
-            CrawlWgGesucht(self),
-            CrawlEbayKleinanzeigen(self),
-            CrawlImmowelt(self),
-            CrawlSubito(self),
-            CrawlImmobiliare(self),
-            CrawlIdealista(self),
-            CrawlMeineStadt(self)
+            Immobilienscout(self),
+            WgGesucht(self),
+            EbayKleinanzeigen(self),
+            Immowelt(self),
+            Subito(self),
+            Immobiliare(self),
+            Idealista(self),
+            MeineStadt(self)
         ]
 
     def check_deprecated(self):

--- a/flathunter/crawler/ebaykleinanzeigen.py
+++ b/flathunter/crawler/ebaykleinanzeigen.py
@@ -7,7 +7,7 @@ from bs4 import Tag
 from flathunter.logging import logger
 from flathunter.abstract_crawler import Crawler
 
-class CrawlEbayKleinanzeigen(Crawler):
+class EbayKleinanzeigen(Crawler):
     """Implementation of Crawler interface for Ebay Kleinanzeigen"""
 
     URL_PATTERN = re.compile(r'https://www\.kleinanzeigen\.de')

--- a/flathunter/crawler/idealista.py
+++ b/flathunter/crawler/idealista.py
@@ -4,7 +4,7 @@ import re
 from flathunter.logging import logger
 from flathunter.abstract_crawler import Crawler
 
-class CrawlIdealista(Crawler):
+class Idealista(Crawler):
     """Implementation of Crawler interface for Idealista"""
 
     URL_PATTERN = re.compile(r'https://www\.idealista\.it')

--- a/flathunter/crawler/immobiliare.py
+++ b/flathunter/crawler/immobiliare.py
@@ -5,7 +5,7 @@ from flathunter.logging import logger
 from flathunter.abstract_crawler import Crawler
 
 
-class CrawlImmobiliare(Crawler):
+class Immobiliare(Crawler):
     """Implementation of Crawler interface for Immobiliare"""
 
     URL_PATTERN = re.compile(r'https://www\.immobiliare\.it')

--- a/flathunter/crawler/immobiliare.py
+++ b/flathunter/crawler/immobiliare.py
@@ -42,8 +42,8 @@ class Immobiliare(Crawler):
             details_list = row.find(
                 "ul", {"class": "in-realEstateListCard__features"})
 
-            price_li = details_list.find(
-                "li", {"class": "in-realEstateListCard__features--main"})
+            price_li = row.find(
+                "div", {"class": "in-realEstateListCard__priceOnTop"})
 
             price_re = re.match(
                 r".*\s([0-9]+.*)$",

--- a/flathunter/crawler/immobilienscout.py
+++ b/flathunter/crawler/immobilienscout.py
@@ -29,7 +29,7 @@ def get_result_count(soup: BeautifulSoup) -> int:
         return 0
     return int(count_element.text.replace('.', ''))
 
-class CrawlImmobilienscout(Crawler):
+class Immobilienscout(Crawler):
     """Implementation of Crawler interface for ImmobilienScout"""
 
     URL_PATTERN = STATIC_URL_PATTERN

--- a/flathunter/crawler/immowelt.py
+++ b/flathunter/crawler/immowelt.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup, Tag
 from flathunter.logging import logger
 from flathunter.abstract_crawler import Crawler
 
-class CrawlImmowelt(Crawler):
+class Immowelt(Crawler):
     """Implementation of Crawler interface for ImmoWelt"""
 
     URL_PATTERN = re.compile(r'https://www\.immowelt\.de')

--- a/flathunter/crawler/meinestadt.py
+++ b/flathunter/crawler/meinestadt.py
@@ -7,7 +7,7 @@ from flathunter.logging import logger
 from flathunter.abstract_crawler import Crawler
 
 
-class CrawlMeineStadt(Crawler):
+class MeineStadt(Crawler):
     """Implementation of Crawler interface for MeineStadt"""
 
     URL_PATTERN = re.compile(r'https://www\.meinestadt\.de')

--- a/flathunter/crawler/subito.py
+++ b/flathunter/crawler/subito.py
@@ -5,7 +5,7 @@ import json
 from flathunter.logging import logger
 from flathunter.abstract_crawler import Crawler
 
-class CrawlSubito(Crawler):
+class Subito(Crawler):
     """Implementation of Crawler interface for Subito"""
 
     URL_PATTERN = re.compile(r'https://www\.subito\.it')

--- a/flathunter/crawler/wggesucht.py
+++ b/flathunter/crawler/wggesucht.py
@@ -147,7 +147,7 @@ def liste_attribute_filter(element: Union[Tag, str]) -> bool:
     return element.attrs["id"].startswith('liste-')
 
 
-class CrawlWgGesucht(Crawler):
+class WgGesucht(Crawler):
     """Implementation of Crawler interface for WgGesucht"""
 
     URL_PATTERN = re.compile(r'https://www\.wg-gesucht\.de')

--- a/test/test_crawl_ebaykleinanzeigen.py
+++ b/test/test_crawl_ebaykleinanzeigen.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flathunter.crawler.ebaykleinanzeigen import CrawlEbayKleinanzeigen
+from flathunter.crawler.ebaykleinanzeigen import EbayKleinanzeigen
 from test.utils.config import StringConfig
 
 DUMMY_CONFIG = """
@@ -12,7 +12,7 @@ TEST_URL = 'https://www.kleinanzeigen.de/s-wohnung-mieten/berlin/preis:1000:1500
 
 @pytest.fixture
 def crawler():
-    return CrawlEbayKleinanzeigen(StringConfig(string=DUMMY_CONFIG))
+    return EbayKleinanzeigen(StringConfig(string=DUMMY_CONFIG))
 
 def test_crawler(crawler):
     soup = crawler.get_page(TEST_URL)

--- a/test/test_crawl_immobiliare.py
+++ b/test/test_crawl_immobiliare.py
@@ -1,5 +1,5 @@
 import unittest
-from flathunter.crawler.immobiliare import CrawlImmobiliare
+from flathunter.crawler.immobiliare import Immobiliare
 from test.utils.config import StringConfig
 
 
@@ -12,7 +12,7 @@ class ImmobiliareCrawlerTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.crawler = CrawlImmobiliare(StringConfig(string=self.DUMMY_CONFIG))
+        self.crawler = Immobiliare(StringConfig(string=self.DUMMY_CONFIG))
 
     def test(self):
         soup = self.crawler.get_page(self.TEST_URL)

--- a/test/test_crawl_immobilienscout.py
+++ b/test/test_crawl_immobilienscout.py
@@ -4,7 +4,7 @@ import os
 import requests_mock
 import re
 
-from flathunter.crawler.immobilienscout import CrawlImmobilienscout
+from flathunter.crawler.immobilienscout import Immobilienscout
 from flathunter.captcha.captcha_solver import CaptchaBalanceEmpty
 from test.utils.config import StringConfigWithCaptchas
 
@@ -20,7 +20,7 @@ test_config = StringConfigWithCaptchas(string=DUMMY_CONFIG)
 
 @pytest.fixture
 def crawler():
-    return CrawlImmobilienscout(test_config)
+    return Immobilienscout(test_config)
 
 def test_parse_exposes_from_json(crawler):
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures", "immo-scout-IS24-object.json")) as fixture:

--- a/test/test_crawl_immowelt.py
+++ b/test/test_crawl_immowelt.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flathunter.crawler.immowelt import CrawlImmowelt
+from flathunter.crawler.immowelt import Immowelt
 from test.test_util import count
 from test.utils.config import StringConfig
 
@@ -13,7 +13,7 @@ TEST_URL = 'https://www.immowelt.de/liste/berlin/wohnungen/mieten?roomi=2&prima=
 
 @pytest.fixture
 def crawler():
-    return CrawlImmowelt(StringConfig(string=DUMMY_CONFIG))
+    return Immowelt(StringConfig(string=DUMMY_CONFIG))
 
 
 def test_crawler(crawler):

--- a/test/test_crawl_meinestadt.py
+++ b/test/test_crawl_meinestadt.py
@@ -1,5 +1,5 @@
 import unittest
-from flathunter.crawler.meinestadt import CrawlMeineStadt
+from flathunter.crawler.meinestadt import MeineStadt
 from test.utils.config import StringConfig
 
 
@@ -12,7 +12,7 @@ class MeineStadtCrawlerTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.crawler = CrawlMeineStadt(StringConfig(string=self.DUMMY_CONFIG))
+        self.crawler = MeineStadt(StringConfig(string=self.DUMMY_CONFIG))
 
     def test(self):
         soup = self.crawler.get_page(self.TEST_URL)

--- a/test/test_crawl_wggesucht.py
+++ b/test/test_crawl_wggesucht.py
@@ -1,6 +1,6 @@
 import unittest
 from functools import reduce
-from flathunter.crawler.wggesucht import CrawlWgGesucht
+from flathunter.crawler.wggesucht import WgGesucht
 from test.utils.config import StringConfig
 
 class WgGesuchtCrawlerTest(unittest.TestCase):
@@ -11,7 +11,7 @@ class WgGesuchtCrawlerTest(unittest.TestCase):
       - https://www.wg-gesucht.de/wohnungen-in-Munchen.90.2.1.0.html
         """
     def setUp(self):
-        self.crawler = CrawlWgGesucht(StringConfig(string=self.DUMMY_CONFIG))
+        self.crawler = WgGesucht(StringConfig(string=self.DUMMY_CONFIG))
 
     def test(self):
         soup = self.crawler.get_page(self.TEST_URL)

--- a/test/test_hunter.py
+++ b/test/test_hunter.py
@@ -1,7 +1,7 @@
 import unittest
 import re
 from typing import Optional, Dict, List
-from flathunter.crawler.immowelt import CrawlImmowelt
+from flathunter.crawler.immowelt import Immowelt
 from flathunter.hunter import Hunter 
 from flathunter.idmaintainer import IdMaintainer
 from test.dummy_crawler import DummyCrawler
@@ -111,7 +111,7 @@ excluded_titles:
 
     def test_hunt_flats(self):
         config = StringConfig(string=self.DUMMY_CONFIG)
-        config.set_searchers([CrawlImmowelt(config)])
+        config.set_searchers([Immowelt(config)])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         exposes = hunter.hunt_flats()
         self.assertTrue(count(exposes) > 0, "Expected to find exposes")


### PR DESCRIPTION
This PR is just for the class namings because we do not need the Prefix in any way.
Also all crawlers are now inside a 'crawler' folder. 