### PR TITLE
fix #465: determine Chrome version on Windows

### DIFF
--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -3,11 +3,11 @@ binary is, to attach the correct selenium chromedriver, and to set
 the correct version number"""
 import re
 import subprocess
+from typing import List
 import undetected_chromedriver as uc
 
 from flathunter.logging import logger
 from flathunter.exceptions import ChromeNotFound
-from typing import List
 
 CHROME_VERSION_REGEXP = re.compile(r'.* (\d+\.\d+\.\d+\.\d+)( .*)?')
 WINDOWS_CHROME_REG_PATH = r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon'

--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -44,11 +44,10 @@ def get_chrome_version() -> int:
         output = get_command_output(
             ['reg', 'query', WINDOWS_CHROME_REG_PATH, '/v', 'version']
         )
-        version_line = [p for p in output if WINDOWS_CHROME_REG_REGEXP.match(p)]
-        if version_line:
-            version = WINDOWS_CHROME_REG_REGEXP.match(version_line[0])
-            if version is not None:
-                return int(version.group(1))
+        version_matches = (WINDOWS_CHROME_REG_REGEXP.match(l) for l in output)
+        version_matches = [m for m in version_matches if m is not None]
+        if version_matches:
+            return int(version_matches[0].group(1))
     except FileNotFoundError:
         pass
     raise ChromeNotFound()

--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -7,12 +7,13 @@ import undetected_chromedriver as uc
 
 from flathunter.logging import logger
 from flathunter.exceptions import ChromeNotFound
+from typing import List
 
 CHROME_VERSION_REGEXP = re.compile(r'.* (\d+\.\d+\.\d+\.\d+)( .*)?')
 WINDOWS_CHROME_REG_PATH = r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon'
 WINDOWS_CHROME_REG_REGEXP = re.compile(r'\s*version\s*REG_SZ\s*(\d+)\..*')
 
-def get_command_output(args) -> list[str]:
+def get_command_output(args) -> List[str]:
     """Run a command and return stdout"""
     try:
         with subprocess.Popen(args,
@@ -40,7 +41,9 @@ def get_chrome_version() -> int:
     try:
         # on Windows, Chrome doesn't respond to --version, but we can find
         # the version in the registry
-        output = get_command_output(['reg', 'query', WINDOWS_CHROME_REG_PATH, '/v', 'version'])
+        output = get_command_output(
+            ['reg', 'query', WINDOWS_CHROME_REG_PATH, '/v', 'version']
+        )
         version_line = [p for p in output if WINDOWS_CHROME_REG_REGEXP.match(p)]
         if version_line:
             version = WINDOWS_CHROME_REG_REGEXP.match(version_line[0])

--- a/test/test_chrome_wrapper.py
+++ b/test/test_chrome_wrapper.py
@@ -5,18 +5,39 @@ from unittest.mock import patch
 from flathunter.chrome_wrapper import get_chrome_version
 from flathunter.exceptions import ChromeNotFound
 
+CHROME_VERSION_RESULTS = [
+        [], [], [],
+        [], ['Chromium 107.0.5304.87 built on Debian bookworm/sid, running on Debian bookworm/sid'],
+        ['Google Chrome 107.0.5304.110'],
+        ['Chromium 107.0.5304.87 built on Debian 11.5, running on Debian 11.5'],
+        [], [], [],
+    ]
+REG_VERSION_RESULTS = [
+        [],
+        [
+            '',
+            r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon',
+            '    version    REG_SZ    116.0.5845.141',
+            '',
+        ]
+    ]
+
+def my_subprocess_mock(args, static={ 'chrome_calls': 0, 'reg_calls': 0 }):
+    if 'chrom' in args[0]:
+        static['chrome_calls'] += 1
+        return CHROME_VERSION_RESULTS[static['chrome_calls'] - 1]
+    if 'reg' in args[0]:
+        static['reg_calls'] += 1
+        return REG_VERSION_RESULTS[static['reg_calls'] - 1]
+
 class ChromeWrapperTest(unittest.TestCase):
 
     @patch("flathunter.chrome_wrapper.get_command_output")
     def test_parse_chrome_version(self, subprocess_mock):
-        subprocess_mock.side_effect = [
-            None, None, None,
-            None, 'Chromium 107.0.5304.87 built on Debian bookworm/sid, running on Debian bookworm/sid',
-            'Google Chrome 107.0.5304.110',
-            'Chromium 107.0.5304.87 built on Debian 11.5, running on Debian 11.5'
-        ]
+        subprocess_mock.side_effect = my_subprocess_mock
         with pytest.raises(ChromeNotFound):
             self.assertEqual(get_chrome_version(), None)
         self.assertEqual(get_chrome_version(), 107)
         self.assertEqual(get_chrome_version(), 107)
         self.assertEqual(get_chrome_version(), 107)
+        self.assertEqual(get_chrome_version(), 116)


### PR DESCRIPTION
We can use the `reg` util to access the registry on Windows -- this enables us to find the installed version of Google Chrome, as Chrome does not respond to --version on Windows.