### PR TITLE
Google Maps filter

### DIFF
--- a/flathunter/dataclasses.py
+++ b/flathunter/dataclasses.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class TransportationModes(Enum):
+    """The transportation mode for Google Maps distance calculation."""
+    TRANSIT = 'transit'
+    BICYCLING = 'bicycling'
+    DRIVING = 'driving'
+    WALKING = 'walking'
+
+
+@dataclass
+class DistanceValueTuple:
+    """We want to keep both the numeric value of a distance, and its string representation."""
+    meters: float
+    text: str
+
+
+@dataclass
+class DurationValueTuple:
+    """We want to keep both the numeric value of a duration, and its string representation."""
+    seconds: float
+    text: str
+
+
+@dataclass
+class DistanceElement:
+    """Represents the distance from a property to some location."""
+    duration: DurationValueTuple
+    distance: DistanceValueTuple
+    mode: TransportationModes
+
+
+@dataclass
+class DistanceConfig:
+    """Represents distance filter information in the configuration file.
+    
+    location_name must refer to the location name used to identify the location
+    in the durations section of the config file, and the transport_mode must be
+    configured in the durations section for that location name, lest no information
+    is available to actually filter on."""
+    location_name: str
+    transport_mode: TransportationModes
+    max_distance_meters: Optional[float]
+    max_duration_seconds: Optional[float]
+
+
+class FilterChainName(Enum):
+    """Identifies the filter chain that a filter acts on
+    
+    Preprocess filters will be run before the expose is processed by any further actions.
+    Use this chain to filter exposes that can be excluded based on information scraped 
+    from the expose website alone (such as based on price or size).
+    Postprocess filters will be run after other actions have completed. Use this if you
+    require additional information from other steps, such as information from the Google
+    Maps API, to make a decision on this expose.
+    
+    We separate the filter chains to avoid making expensive (literally!) calls to the
+    Google Maps API for exposes that we already know we aren't interested in anyway.""" 
+    preprocess = 'PREPROCESS'
+    postprocess = 'POSTPROCESS'

--- a/flathunter/web/views.py
+++ b/flathunter/web/views.py
@@ -6,10 +6,11 @@ from urllib import parse
 
 from flask import render_template, jsonify, request, session, redirect
 from flask_api import status
+from flathunter.dataclasses import FilterChainName
 
 from flathunter.web import app, log
 from flathunter.web.util import sanitize_float
-from flathunter.filter import FilterBuilder
+from flathunter.filter import FilterChainBuilder
 from flathunter.config import YamlConfig
 
 class AuthenticationError(Exception):
@@ -72,7 +73,10 @@ def filter_for_user():
     """Load the filter for the current user"""
     if filter_values_for_user() is None:
         return None
-    return FilterBuilder().read_config(YamlConfig({'filters': filter_values_for_user()})).build()
+    return (FilterChainBuilder()
+            .read_config(YamlConfig({'filters': filter_values_for_user()}), FilterChainName.preprocess)
+            .read_config(YamlConfig({'filters': filter_values_for_user()}), FilterChainName.postprocess)
+            .build())
 
 def form_filter_values():
     """Extract the filter settings from the submitted form"""

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -58,11 +58,16 @@ filters:
             os.remove("config.yaml")
 
     def test_loads_config_at_file(self):
-       with tempfile.NamedTemporaryFile(mode='w+') as temp:
-          temp.write(self.DUMMY_CONFIG)
-          temp.flush()
-          config = Config(temp.name) 
-       self.assertTrue(len(config.get('urls', [])) > 0, "Expected URLs in config file")
+       tempFileName = None
+       try:
+         with tempfile.NamedTemporaryFile(mode='w+', delete=False) as temp:
+            temp.write(self.DUMMY_CONFIG)
+            temp.flush()
+            tempFileName = temp.name
+         config = Config(tempFileName) 
+         self.assertTrue(len(config.get('urls', [])) > 0, "Expected URLs in config file")
+       finally:
+         os.unlink(tempFileName)
 
     def test_loads_config_from_string(self):
        config = StringConfig(string=self.EMPTY_FILTERS_CONFIG)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -71,22 +71,20 @@ filters:
 
     def test_loads_config_from_string(self):
        config = StringConfig(string=self.EMPTY_FILTERS_CONFIG)
-       self.assertIsNotNone(config)
-       my_filter = config.get_filter()
-       self.assertIsNotNone(my_filter)
+       target_urls = config.target_urls()
+       self.assertIsNotNone(target_urls)
 
     def test_loads_legacy_config_from_string(self):
        config = StringConfig(string=self.LEGACY_FILTERS_CONFIG)
-       self.assertIsNotNone(config)
-       my_filter = config.get_filter()
+       my_filter = config.excluded_titles()
        self.assertIsNotNone(my_filter)
-       self.assertTrue(len(my_filter.filters) > 0)
+       self.assertTrue(len(my_filter) > 0)
 
     def test_loads_filters_config_from_string(self):
        config = StringConfig(string=self.FILTERS_CONFIG)
-       self.assertIsNotNone(config)
-       my_filter = config.get_filter()
+       my_filter = config.excluded_titles()
        self.assertIsNotNone(my_filter)
+       self.assertTrue(len(my_filter) > 0)
 
     def test_defaults_fields(self):
        config = StringConfig(string=self.FILTERS_CONFIG)

--- a/test/test_gmaps_duration_processor.py
+++ b/test/test_gmaps_duration_processor.py
@@ -1,6 +1,7 @@
+from typing import Dict
 import unittest
-import yaml
 import re
+from flathunter.gmaps_duration_processor import DistanceElement
 import requests_mock
 from flathunter.hunter import Hunter
 from flathunter.idmaintainer import IdMaintainer
@@ -33,6 +34,20 @@ durations:
       - gm_id: driving
         title: Car
     """
+    DUMMY_RESPONSE = """
+    {
+      "status": "OK",
+      "rows": [
+        {
+          "elements": [
+            {
+              "distance": { "text": "228 mi", "value": 367654 },
+              "duration": { "text": "3 hours 55 mins", "value": 14078 }
+            }
+          ]
+        }
+      ]
+    }"""
 
     @requests_mock.Mocker()
     def test_resolve_durations(self, m):
@@ -40,11 +55,25 @@ durations:
         config.set_searchers([DummyCrawler()])
         hunter = Hunter(config, IdMaintainer(":memory:"))
         matcher = re.compile('maps.googleapis.com/maps/api/distancematrix/json')
-        m.get(matcher, text='{"status": "OK", "rows": [ { "elements": [ { "distance": { "text": "far", "value": 123 }, "duration": { "text": "days", "value": 123 } } ] } ]}')
+        m.get(matcher, text=self.DUMMY_RESPONSE)
         exposes = hunter.hunt_flats()
         self.assertTrue(count(exposes) > 4, "Expected to find exposes")
         without_durations = list(filter(lambda expose: 'durations' not in expose, exposes))
-        if len(without_durations) > 0:
-            for expose in without_durations:
-                print("Got expose: ", expose)
+        for expose in without_durations:
+            print("Got expose: ", expose)
         self.assertTrue(len(without_durations) == 0, "Expected durations to be calculated")
+    
+    @requests_mock.Mocker()
+    def test_durations_valid(self, m):
+        config = StringConfig(string=self.DUMMY_CONFIG)
+        config.set_searchers([DummyCrawler()])
+        hunter = Hunter(config, IdMaintainer(":memory:"))
+        matcher = re.compile('maps.googleapis.com/maps/api/distancematrix/json')
+        m.get(matcher, text=self.DUMMY_RESPONSE)
+        exposes = hunter.hunt_flats()
+        for expose in exposes:
+            durations: Dict[str, DistanceElement] = expose['durations_unformatted']
+            for duration in durations.values():
+                self.assertAlmostEqual(duration.distance.meters, 367654)
+                self.assertAlmostEqual(duration.duration.seconds, 14078)
+                self.assertEqual(duration.duration.text, '3 hours 55 mins')

--- a/test/test_googlecloud_idmaintainer.py
+++ b/test/test_googlecloud_idmaintainer.py
@@ -7,7 +7,8 @@ from mockfirestore import MockFirestore
 from flathunter.googlecloud_idmaintainer import GoogleCloudIdMaintainer
 from flathunter.hunter import Hunter
 from flathunter.web_hunter import WebHunter
-from flathunter.filter import Filter
+from flathunter.filter import FilterChain
+from flathunter.dataclasses import FilterChainName
 from test.dummy_crawler import DummyCrawler
 from test.test_util import count
 from test.utils.config import StringConfig
@@ -94,7 +95,10 @@ def test_exposes_are_returned_filtered(id_watch):
     hunter = Hunter(config, id_watch)
     hunter.hunt_flats()
     hunter.hunt_flats()
-    filter = Filter.builder().read_config(StringConfig('{"filters":{"max_size":70}}')).build()
+    filter = (FilterChain
+            .builder()
+            .read_config(StringConfig('{"filters":{"max_size":70}}'), FilterChainName.preprocess)
+            .build())
     saved = id_watch.get_recent_exposes(10, filter_set=filter)
     assert len(saved) == 10
     for expose in saved:

--- a/test/test_id_maintainer.py
+++ b/test/test_id_maintainer.py
@@ -6,7 +6,8 @@ from typing import Dict
 from flathunter.idmaintainer import IdMaintainer
 from flathunter.hunter import Hunter
 from flathunter.web_hunter import WebHunter
-from flathunter.filter import Filter
+from flathunter.filter import FilterChain
+from flathunter.dataclasses import FilterChainName
 from test.dummy_crawler import DummyCrawler
 from test.test_util import count
 from test.utils.config import StringConfig
@@ -111,7 +112,10 @@ def test_exposes_are_returned_filtered():
     hunter = Hunter(config, id_watch)
     hunter.hunt_flats()
     hunter.hunt_flats()
-    filter = Filter.builder().read_config(StringConfig('{"filters":{"max_size":70}}')).build()
+    filter = (FilterChain
+            .builder()
+            .read_config(StringConfig('{"filters":{"max_size":70}}'), FilterChainName.preprocess)
+            .build())
     saved = id_watch.get_recent_exposes(10, filter_set=filter)
     assert len(saved) == 10
     for expose in saved:


### PR DESCRIPTION
feature #472: filter based on GMaps distance

This PR involves some refactoring. The problem is that previously,
filters ran before making any calls to external APIs. Therefore, just
adding another filter for the distance doesn't actually work: the
distance information is not yet available when we apply the filters. We
can't just run the filters later, because then we would run the Google
Maps API calls before we filtered out any properties, meaning that we
would incur Google Maps API calls for all properties that we find in our
search, including those that we later filter out anyway based on price,
size, etc. - and we actually have to pay for those requests! My solution
is to group the filters in two chains, and then run one chain before and
one after external API calls have been made. This way, we can run the
distance filter after the API calls are made, but keep everything else
the same.
