### PR TITLE
Force modern user agent in Chrome driver to pass Immoscout bot detection in headless mode

### DIFF
--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -69,6 +69,13 @@ def get_chrome_driver(driver_arguments):
     setattr(chrome_options, "headless", True)
     driver = uc.Chrome(version_main=chrome_version, options=chrome_options) # pylint: disable=no-member
 
+    driver.execute_cdp_cmd(
+        "Network.setUserAgentOverride",
+        {
+            "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        },
+    )
+
     driver.execute_cdp_cmd('Network.setBlockedURLs',
         {"urls": ["https://api.geetest.com/get.*"]})
     driver.execute_cdp_cmd('Network.enable', {})

--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -72,7 +72,9 @@ def get_chrome_driver(driver_arguments):
     driver.execute_cdp_cmd(
         "Network.setUserAgentOverride",
         {
-            "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+                         "AppleWebKit/537.36 (KHTML, like Gecko)"
+                         "Chrome/120.0.0.0 Safari/537.36"
         },
     )
 


### PR DESCRIPTION
This simple change changes the ChromeDriver's user agent from the default to a recent one. Apparently this is all I needed to change to pass the bot detection at Immoscout24. Captcha solving is still needed of course.