### PR TITLE
Fix for wggesucht crawler to only consider the desired listings

### DIFF
--- a/flathunter/crawler/wggesucht.py
+++ b/flathunter/crawler/wggesucht.py
@@ -149,7 +149,7 @@ def parse_expose_element_to_details(row: Tag, crawler: str) -> Optional[Dict]:
 
 def liste_attribute_filter(element: Union[Tag, str]) -> bool:
     """Return true for elements whose 'id' attribute starts with 'liste-' 
-    and are not contained in the random results container 'premium_user_extra_list'"""
+    and are not contained in the 'premium_user_extra_list' container"""
     if not isinstance(element, Tag):
         return False
     if not element.attrs or "id" not in element.attrs:

--- a/flathunter/crawler/wggesucht.py
+++ b/flathunter/crawler/wggesucht.py
@@ -148,14 +148,16 @@ def parse_expose_element_to_details(row: Tag, crawler: str) -> Optional[Dict]:
 
 
 def liste_attribute_filter(element: Union[Tag, str]) -> bool:
-    """Return true for elements whose 'id' attribute starts with 'liste-' and are contained in a parent with an 'id' attribute of 'main_column'"""
+    """Return true for elements whose 'id' attribute starts with 'liste-' 
+    and are not contained in the random results container 'premium_user_extra_list'"""
     if not isinstance(element, Tag):
         return False
-    if "id" not in element.attrs:
+    if not element.attrs or "id" not in element.attrs:
         return False
-    if "id" not in element.parent.attrs:
+    if not element.parent or not element.parent.attrs or "class" not in element.parent.attrs:
         return False
-    return element.attrs["id"].startswith('liste-') and element.parent.attrs["id"].startswith('main_column')
+    return element.attrs["id"].startswith('liste-') and \
+        'premium_user_extra_list' not in element.parent.attrs["class"]
 
 
 class WgGesucht(Crawler):
@@ -177,7 +179,6 @@ class WgGesucht(Crawler):
             e for e in findings
             if isinstance(e, Tag) and e.has_attr('class') and not 'display-none' in e['class']
         ]
-
         for row in existing_findings:
             details = parse_expose_element_to_details(row, self.get_name())
             if details is None:

--- a/flathunter/crawler/wggesucht.py
+++ b/flathunter/crawler/wggesucht.py
@@ -148,12 +148,14 @@ def parse_expose_element_to_details(row: Tag, crawler: str) -> Optional[Dict]:
 
 
 def liste_attribute_filter(element: Union[Tag, str]) -> bool:
-    """Return true for elements whose 'id' attribute starts with 'liste-'"""
+    """Return true for elements whose 'id' attribute starts with 'liste-' and are contained in a parent with an 'id' attribute of 'main_column'"""
     if not isinstance(element, Tag):
         return False
     if "id" not in element.attrs:
         return False
-    return element.attrs["id"].startswith('liste-')
+    if "id" not in element.parent.attrs:
+        return False
+    return element.attrs["id"].startswith('liste-') and element.parent.attrs["id"].startswith('main_column')
 
 
 class WgGesucht(Crawler):


### PR DESCRIPTION
I've started my flathunting journey today and noticed that on wg-gesucht.de some (very old) listings were presented to me various times even though they were not even included in what I was searching for. Turns out wg-gesucht includes additional results in a div they label "premium_user_extra_list". 
Those additional results are currently not filtered out because only the elements themselves are checked for the correct id of "liste-", which wouldn't be a big deal if they are included once in the beginning and then blocked on subsequent refreshs thanks to the to id_maintainer. But unfortunately the additional listings are somewhat random on each page refresh, presenting you at times with listings that are months old.

This PR changes the filter to only consider the desired search results by looking at the parent elements id and making sure it's 'main_column' and not 'premium_user_extra_list', which had the additional results. 

On the page: 
<img width="943" alt="Screenshot 2024-01-17 at 17 03 07" src="https://github.com/flathunters/flathunter/assets/100701133/53a49fa2-2975-43b9-8533-4d83870e31e0">

In HTML: 
<img width="685" alt="Screenshot 2024-01-17 at 17 05 34" src="https://github.com/flathunters/flathunter/assets/100701133/b08d063f-1601-4422-9e0a-24d9c4970cb7">
