### PR TITLE
Fix minor issues with Immoscout24 image extraction

### DIFF
--- a/flathunter/crawler/immobilienscout.py
+++ b/flathunter/crawler/immobilienscout.py
@@ -4,7 +4,7 @@ import datetime
 import re
 
 from bs4 import BeautifulSoup, Tag
-from jsonpath_ng import parse
+from jsonpath_ng.ext import parse
 from selenium.common.exceptions import JavascriptException
 from selenium.webdriver import Chrome
 
@@ -35,7 +35,8 @@ class Immobilienscout(Crawler):
     URL_PATTERN = STATIC_URL_PATTERN
 
     JSON_PATH_PARSER_ENTRIES = parse("$..['resultlist.realEstate']")
-    JSON_PATH_PARSER_IMAGES = parse("$..galleryAttachments..['@href']")
+    JSON_PATH_PARSER_IMAGES = parse("$..galleryAttachments..attachment[?'@xsi.type'=='common:Picture']"
+                                    "..['@href']")
 
     RESULT_LIMIT = 50
 

--- a/flathunter/crawler/immobilienscout.py
+++ b/flathunter/crawler/immobilienscout.py
@@ -36,7 +36,7 @@ class Immobilienscout(Crawler):
 
     JSON_PATH_PARSER_ENTRIES = parse("$..['resultlist.realEstate']")
     JSON_PATH_PARSER_IMAGES = parse("$..galleryAttachments..attachment[?'@xsi.type'=='common:Picture']"
-                                    "..['@href']")
+                                    "..['@href'].`sub(/(.*\\\\.jpe?g).*/, \\\\1)`")
 
     RESULT_LIMIT = 50
 
@@ -146,10 +146,7 @@ class Immobilienscout(Crawler):
         #
         # After: https://pictures.immobilienscout24.de/listings/$$IMAGE_ID$$.jpg
 
-        images = [
-            image.value[:image.value.find(".jpg") + 4]
-                for image in self.JSON_PATH_PARSER_IMAGES.find(entry)
-            ]
+        images = [image.value for image in self.JSON_PATH_PARSER_IMAGES.find(entry)]
 
         object_id: int = int(entry.get("@id", 0))
         return {

--- a/flathunter/crawler/immobilienscout.py
+++ b/flathunter/crawler/immobilienscout.py
@@ -35,7 +35,8 @@ class Immobilienscout(Crawler):
     URL_PATTERN = STATIC_URL_PATTERN
 
     JSON_PATH_PARSER_ENTRIES = parse("$..['resultlist.realEstate']")
-    JSON_PATH_PARSER_IMAGES = parse("$..galleryAttachments..attachment[?'@xsi.type'=='common:Picture']"
+    JSON_PATH_PARSER_IMAGES = parse("$..galleryAttachments"
+                                    "..attachment[?'@xsi.type'=='common:Picture']"
                                     "..['@href'].`sub(/(.*\\\\.jpe?g).*/, \\\\1)`")
 
     RESULT_LIMIT = 50


### PR DESCRIPTION
This pull request fixes two minor issues I've encountered in the log while scraping Immoscout24 results.

777ad0c7a2743d51597a3414ad91cda699683e50: Some images on scraped listings are rejected by Telegram for being Webp files, as they fall through the filter that shortens them to just the `.jpg` link. Those are the images used to link to virtual viewings and are apparently just [basic placeholders](
![](http://s3-eu-west-1.amazonaws.com/is24-search-static/360-default-image-01.jpg)
). They're recognisable by the `@xsi.type` property being set to `common:VirtualTour` so it's easiest just to exclude everything but `common:Picture` altogether.

c1c6c4fc9fc81c0548989c236c21eb85562bd366: In some cases, the same filter shortened image links to just a few characters, which failed to be submitted to Telegram as a result. I found this is due to some images on Immoscout carrying the `.jpeg` extension, with an extra e over `.jpg`. The filter had to take that into account so I built it as a regex into the jsonpath filter.

Neither of these issues was fatal, but this should result in more images successfully scraped and sent as well as less error messages and unsuccessful API calls to notification platforms.