### PR TITLE
Add Fedora Chromium binary name to chrome_wrapper

### DIFF
--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -28,7 +28,7 @@ def get_command_output(args) -> List[str]:
 
 def get_chrome_version() -> int:
     """Determine the correct name for the chrome binary"""
-    for binary_name in ['google-chrome', 'chromium', 'chrome',
+    for binary_name in ['google-chrome', 'chromium', 'chrome', 'chromium-browser',
                         '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome']:
         try:
             version_output = get_command_output([binary_name, '--version'])

--- a/test/test_chrome_wrapper.py
+++ b/test/test_chrome_wrapper.py
@@ -6,11 +6,11 @@ from flathunter.chrome_wrapper import get_chrome_version
 from flathunter.exceptions import ChromeNotFound
 
 CHROME_VERSION_RESULTS = [
-        [], [], [],
-        [], ['Chromium 107.0.5304.87 built on Debian bookworm/sid, running on Debian bookworm/sid'],
+        [], [], [], [],
+        ['Chromium 107.0.5304.87 built on Debian bookworm/sid, running on Debian bookworm/sid'],
         ['Google Chrome 107.0.5304.110'],
         ['Chromium 107.0.5304.87 built on Debian 11.5, running on Debian 11.5'],
-        [], [], [],
+        [], [], [], [],
     ]
 REG_VERSION_RESULTS = [
         [],


### PR DESCRIPTION
Under Fedora the chromium browser binary is named 'chromium-browser'.
This binary name is missing in the chrome-wrapper.py, therefore it is throwing an ChromeNotFound Exception.
This PR simply adds this name to the list of strings the wrapper executes to find the chromium browser.