### PR TITLE
Update to new selenium chrome headless argument

### DIFF
--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -64,9 +64,7 @@ def get_chrome_driver(driver_arguments):
         for driver_argument in driver_arguments:
             chrome_options.add_argument(driver_argument)
     chrome_version = get_chrome_version()
-    # something is weird with the patched driver version (maybe only in python3.11), I had to patch
-    # the chrome options to make it work
-    setattr(chrome_options, "headless", True)
+    chrome_options.add_argument("--headless=new")
     driver = uc.Chrome(version_main=chrome_version, options=chrome_options) # pylint: disable=no-member
 
     driver.execute_cdp_cmd(


### PR DESCRIPTION
According to the [Selenium Dev blog](https://www.selenium.dev/blog/2023/headless-is-going-away/) the headless argument to start a headless chromium instance changed.
To be precise it changed from:
`chrome_options.add_argument("--headless")`
to
`chrome_options.add_argument("--headless=new")`

At the same time i also removed the workaround at line 67-69:
```
    # something is weird with the patched driver version (maybe only in python3.11), I had to patch
    # the chrome options to make it work
    setattr(chrome_options, "headless", True)
```

`setattr` is setting the headless attribute directly as a child element to chrome_options, in contrast to `chrome_options.add_argument` adding the headless attribute to the list attribute "arguments". (See picture)
![grafik](https://github.com/flathunters/flathunter/assets/6527293/ac005d5c-d23c-40ea-9c3c-465c7509da40)

Therefore i am afraid that the `setattr` is at best useless and at worst it cancels the headless=new again.
