### PR TITLE
Optimize chrome wrapper test and describe functionality

### DIFF
--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -13,6 +13,8 @@ from flathunter.exceptions import ChromeNotFound
 CHROME_VERSION_REGEXP = re.compile(r'.* (\d+\.\d+\.\d+\.\d+)( .*)?')
 WINDOWS_CHROME_REG_PATH = r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon'
 WINDOWS_CHROME_REG_REGEXP = re.compile(r'\s*version\s*REG_SZ\s*(\d+)\..*')
+CHROME_BINARY_NAMES = ['google-chrome', 'chromium', 'chrome', 'chromium-browser',
+                       '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome']
 
 def get_command_output(args) -> List[str]:
     """Run a command and return stdout"""
@@ -28,8 +30,7 @@ def get_command_output(args) -> List[str]:
 
 def get_chrome_version() -> int:
     """Determine the correct name for the chrome binary"""
-    for binary_name in ['google-chrome', 'chromium', 'chrome',
-                        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome']:
+    for binary_name in CHROME_BINARY_NAMES:
         try:
             version_output = get_command_output([binary_name, '--version'])
             if not version_output:

--- a/test/test_chrome_wrapper.py
+++ b/test/test_chrome_wrapper.py
@@ -2,25 +2,45 @@ import pytest
 import unittest
 from unittest.mock import patch
 
-from flathunter.chrome_wrapper import get_chrome_version
+from flathunter.chrome_wrapper import get_chrome_version, CHROME_BINARY_NAMES
 from flathunter.exceptions import ChromeNotFound
 
-CHROME_VERSION_RESULTS = [
-        [], [], [],
-        [], ['Chromium 107.0.5304.87 built on Debian bookworm/sid, running on Debian bookworm/sid'],
-        ['Google Chrome 107.0.5304.110'],
-        ['Chromium 107.0.5304.87 built on Debian 11.5, running on Debian 11.5'],
-        [], [], [],
-    ]
+
+def calc_linux_binary_names():
+	"""
+	Creates a list containing empty lists for each name in CHROME_BINARY_NAMES that does not start with a forward slash.
+	"""
+	return [[] for name in CHROME_BINARY_NAMES if not name.startswith('/')]
+
+
+"""
+The list of mock commands get_command_output should return as an output.
+
+The first returns should all be empty [] so the get_chrome_version function at flathunter/chrome_wrapper.py:31
+thinks no linux chrome is installed and then checks for windows registry entry at flathunter/chrome_wrapper.py:46
+Therefore prepending calc_linux_binary_names().
+Append the same amount empty returns to the end so flathunter/chrome_wrapper.py:31 is forced to check for windows
+again and self.assertEqual(get_chrome_version(), 116) works out
+"""
+CHROME_VERSION_RESULTS = calc_linux_binary_names() + [
+	['Chromium 107.0.5304.87 built on Debian bookworm/sid, running on Debian bookworm/sid'],
+	['Google Chrome 107.0.5304.110'],
+	['Chromium 107.0.5304.87 built on Debian 11.5, running on Debian 11.5'],
+] + calc_linux_binary_names()
+
+"""
+The first return should be empty ([]) so the system thinks no chrome installed at all and
+self.assertEqual(get_chrome_version(), None) works out correctly
+"""
 REG_VERSION_RESULTS = [
-        [],
-        [
-            '',
-            r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon',
-            '    version    REG_SZ    116.0.5845.141',
-            '',
-        ]
-    ]
+	[],
+	[
+		'',
+		r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon',
+		'    version    REG_SZ    116.0.5845.141',
+		'',
+	]
+]
 
 def my_subprocess_mock(args, static={ 'chrome_calls': 0, 'reg_calls': 0 }):
     if 'chrom' in args[0]:


### PR DESCRIPTION
Something like [#526](https://github.com/flathunters/flathunter/pull/526) should not happen again with this PR.

The empty returns are now calculated dynamically by counting the amount of linux binary names in the CHROME_BINARY_NAMES list and prepending/appending it to the "mock return list".

Also some comments about the functionality of this test and why there are  some empty return values for the next contributor.

For this PR to work i had to make the CHROME_BINARY_NAMES list used in the get_chrome_version function globally accessible.
