### PR TITLE
Immoscout crawler: Log number of found entries when using web driver

### DIFF
--- a/flathunter/crawler/immobilienscout.py
+++ b/flathunter/crawler/immobilienscout.py
@@ -129,10 +129,12 @@ class Immobilienscout(Crawler):
 
     def get_entries_from_json(self, json):
         """Get entries from JSON"""
-        return [
+        entries = [
             self.extract_entry_from_javascript(entry.value)
                 for entry in self.JSON_PATH_PARSER_ENTRIES.find(json)
         ]
+        logger.debug('Number of found entries: %d', len(entries))
+        return entries
 
     def extract_entry_from_javascript(self, entry):
         """Get single entry from JavaScript"""


### PR DESCRIPTION
All crawlers report the number of found entries in the debug log, but Immoscout does not when the Selenium web driver is enabled. This makes it a bit inconsistent as it can look like the crawler failed or found no results even when it does, so I made a quick fix to add a debug message.