### PR TITLE
Live update config file without restarting (RFC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ To make deployment with docker easier, most of the important configuration optio
  - FLATHUNTER_GOOGLE_CLOUD_PROJECT_ID - the Google Cloud Project ID, for Google Cloud deployments
  - FLATHUNTER_VERBOSE_LOG - set to any value to enable verbose logging
  - FLATHUNTER_LOOP_PERIOD_SECONDS - a number in seconds for the crawling interval
+ - FLATHUNTER_LOOP_REFRESH_CONFIG - set to any value to enable live editing config file (refresh on each loop)
  - FLATHUNTER_MESSAGE_FORMAT - a format string for the notification messages, where `#CR#` will be replaced by newline
  - FLATHUNTER_NOTIFIERS - a comma-separated list of notifiers to enable (e.g. `telegram,mattermost,slack`)
  - FLATHUNTER_TELEGRAM_BOT_TOKEN - the token for the Telegram notifier

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -10,6 +10,7 @@
 loop:
     active: yes
     sleeping_time: 600
+    refresh_config: no
 
 # Location of the Database to store already seen offerings
 # Defaults to the current directory

--- a/flathunt.py
+++ b/flathunt.py
@@ -22,44 +22,8 @@ __email__ = "harrymcfly@protonmail.com"
 __status__ = "Production"
 
 
-def launch_flat_hunt(config, heartbeat: Heartbeat):
-    """Starts the crawler / notification loop"""
-    id_watch = IdMaintainer(f'{config.database_location()}/processed_ids.db')
-
-    time_from = dtime.fromisoformat(config.loop_pause_from())
-    time_till = dtime.fromisoformat(config.loop_pause_till())
-
-    wait_during_period(time_from, time_till)
-
-    hunter = Hunter(config, id_watch)
-    hunter.hunt_flats()
-    counter = 0
-
-    while config.loop_is_active():
-        wait_during_period(time_from, time_till)
-
-        counter += 1
-        counter = heartbeat.send_heartbeat(counter)
-        time.sleep(config.loop_period_seconds())
-        hunter.hunt_flats()
-
-
-def main():
-    """Processes command-line arguments, loads the config, launches the flathunter"""
-    # load config
-    args = parse()
-    config_handle = args.config
-    if config_handle is not None:
-        config = Config(config_handle.name)
-    else:
-        config = Config()
-
-    # setup logging
-    configure_logging(config)
-
-    # initialize search plugins for config
-    config.init_searchers()
-
+def check_config(config):
+    logger.info("Checking config for errors")
     # check config
     notifiers = config.notifiers()
     if 'mattermost' in notifiers \
@@ -85,6 +49,86 @@ def main():
 
     if len(config.target_urls()) == 0:
         logger.error("No URLs configured. Starting like this would be pointless...")
+        return
+
+    return True
+
+
+def get_heartbeat_instructions(args, config):
+    # get heartbeat instructions
+    heartbeat_interval = args.heartbeat
+    heartbeat = Heartbeat(config, heartbeat_interval)
+    return heartbeat
+
+def launch_flat_hunt(config, heartbeat: Heartbeat):
+    """Starts the crawler / notification loop"""
+    id_watch = IdMaintainer(f'{config.database_location()}/processed_ids.db')
+
+    time_from = dtime.fromisoformat(config.loop_pause_from())
+    time_till = dtime.fromisoformat(config.loop_pause_till())
+
+    wait_during_period(time_from, time_till)
+
+    hunter = Hunter(config, id_watch)
+    hunter.hunt_flats()
+    counter = 0
+
+    while config.loop_is_active():
+        wait_during_period(time_from, time_till)
+
+        counter += 1
+        counter = heartbeat.send_heartbeat(counter)
+        time.sleep(config.loop_period_seconds())
+
+        if config.loop_refresh_config():
+            args = parse()
+            config_handle = args.config
+            if config_handle is not None:
+                new_config = Config(filename=config_handle.name, silent=True)
+
+                if None in (config.last_modified_time, new_config.last_modified_time):
+                    logger.warning("Could not compare last modification time of config file."
+                                 "Keeping the old configuration")
+                elif config.last_modified_time < new_config.last_modified_time:
+                    if not check_config(new_config):
+                        logger.warning("Config changed but new config had errors. Keeping old config")
+                    else:
+                        config = new_config
+                        # setup logging
+                        configure_logging(config)
+
+                        # initialize search plugins for config
+                        config.init_searchers()
+
+                        id_watch = IdMaintainer(f'{new_config.database_location()}/processed_ids.db')
+
+                        time_from = dtime.fromisoformat(new_config.loop_pause_from())
+                        time_till = dtime.fromisoformat(new_config.loop_pause_till())
+
+                        wait_during_period(time_from, time_till)
+
+                        hunter = Hunter(new_config, id_watch)
+
+        hunter.hunt_flats()
+
+
+def main():
+    """Processes command-line arguments, loads the config, launches the flathunter"""
+    # load config
+    args = parse()
+    config_handle = args.config
+    if config_handle is not None:
+        config = Config(config_handle.name)
+    else:
+        config = Config()
+
+    # setup logging
+    configure_logging(config)
+
+    # initialize search plugins for config
+    config.init_searchers()
+
+    if not check_config(config):
         return
 
     # get heartbeat instructions

--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -463,7 +463,7 @@ class Config(CaptchaEnvironmentConfig):  # pylint: disable=too-many-public-metho
 
     def loop_refresh_config(self):
         if Env.FLATHUNTER_LOOP_REFRESH_CONFIG is not None:
-            return str(Env.FLATHUNTER_LOOP_REFRESH_CONFIG)
+            return True
         return super().loop_refresh_config()
 
     def loop_pause_from(self):


### PR DESCRIPTION
So i wanted my instance to run on the server and while the docker container is running I can simply add URLs to the config.yaml that are automatically included in the search without needing to restart the instance.

I don't know if this function is even wanted here, but since its finished and works for me, I thought I would at least offer it.

The following functions are possible with this PR:
- Edit config.yaml and changes are applied live without having to restart the server
- If an error occurs in the edited config file, the change is not applied and the old config is still used.

Steps implemented to achieve these functions:
- checking the correctness of a config has been outsourced to the check_config function
- creation of the heartbeat has been outsourced to the get_heartbeat_instructions function
- A setting "refresh_config: no" was added to config.yaml.dist under the "loop:" tab
- When creating a config object, the timestamp at which the file was last changed on the file system is also saved
- Each time a loop is executed, a check is made to see whether "refresh_config" is true. If so, a new config object is created and compared to see if the timestamps differ from each other
- if the timestamp is more recent, the old config is replaced with the new one and all required objects are reinitialised
- various helper methods and environment variables added
- added readme content for the env variable

If this feature is also useful here, but would have to be adapted before it is merged, I am open to changes.