### PR TITLE
Add option to limit number of images sent via Apprise

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -174,12 +174,15 @@ mattermost:
 # You can find a description how to set up an Apprise url with the official
 # documentation: https://github.com/caronc/apprise
 # Signal notifications are documented here https://github.com/caronc/apprise/wiki/Notify_signal
+# When using the apprise-api (https://github.com/caronc/apprise-api) service,
+# set the limit to 6 images or increase the attachment limit in your apprise-api instance.
 #
 # apprise:
 #   - gotifys://...
 #   - mailto://..
 #   - signal://localhost:9922/{FromPhoneNo}
 # apprise_notify_with_images: true
+# apprise_image_limit: 6
 apprise:
 
 # Sending messages to a Slack channel requires a webhook url. You can find

--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -66,8 +66,10 @@ class Env:
     FLATHUNTER_MATTERMOST_WEBHOOK_URL = _read_env(
         "FLATHUNTER_MATTERMOST_WEBHOOK_URL")
     FLATHUNTER_SLACK_WEBHOOK_URL = _read_env("FLATHUNTER_SLACK_WEBHOOK_URL")
-    FLATHUNTER_APPRISE_NOTIFY_WITH_IMAGES = \
-        _read_env("FLATHUNTER_APPRISE_NOTIFY_WITH_IMAGES")
+    FLATHUNTER_APPRISE_NOTIFY_WITH_IMAGES = _read_env(
+        "FLATHUNTER_APPRISE_NOTIFY_WITH_IMAGES")
+    FLATHUNTER_APPRISE_IMAGE_LIMIT = _read_env(
+        "FLATHUNTER_APPRISE_IMAGE_LIMIT")
 
     # Filters
     FLATHUNTER_FILTER_EXCLUDED_TITLES = _read_env(
@@ -285,6 +287,10 @@ Preis: {price}
         flag = str(self._read_yaml_path(
             "apprise_notify_with_images", 'false'))
         return flag.lower() == 'true'
+
+    def apprise_image_limit(self) -> Optional[int]:
+        """How many images should be sent along with Apprise notifications"""
+        return self._read_yaml_path('apprise_image_limit', None)
 
     def _get_imagetyperz_token(self):
         """API Token for Imagetyperz"""
@@ -526,6 +532,11 @@ class Config(CaptchaEnvironmentConfig):  # pylint: disable=too-many-public-metho
         if Env.FLATHUNTER_APPRISE_NOTIFY_WITH_IMAGES is not None:
             return str(Env.FLATHUNTER_APPRISE_NOTIFY_WITH_IMAGES) == 'true'
         return super().apprise_notify_with_images()
+
+    def apprise_image_limit(self) -> Optional[int]:
+        if Env.FLATHUNTER_APPRISE_IMAGE_LIMIT is not None:
+            return int(Env.FLATHUNTER_APPRISE_IMAGE_LIMIT)
+        return super().apprise_image_limit()
 
     def excluded_titles(self):
         if Env.FLATHUNTER_FILTER_EXCLUDED_TITLES is not None:

--- a/flathunter/notifiers/sender_apprise.py
+++ b/flathunter/notifiers/sender_apprise.py
@@ -37,19 +37,21 @@ class SenderApprise(Processor, Notifier):
             address=expose.get('address', 'N/A'),
             durations=expose.get('durations', 'N/A')
         ).strip()
-        images = (
-            expose.get("images", [expose.get("image")])[: self.__image_limit]
+        images = expose.get("images", [])[: self.__image_limit]
+        image = expose.get("image")
+        attach = (
+            (images if images else image)
             if self.__notify_with_images
             else None
         )
-        self.__send_msg(message, title, images)
+        self.__send_msg(message, title, attach)
         return expose
 
     def notify(self, message: str):
         """Send the given message to users"""
-        self.__send_msg(message=message, title=None, images=None)
+        self.__send_msg(message=message, title=None, attach=None)
 
-    def __send_msg(self, message, title, images):
+    def __send_msg(self, message, title, attach):
         """Send messages to each of the Apprise urls"""
         apobj = apprise.Apprise()
         if self.apprise_urls is None:
@@ -60,6 +62,6 @@ class SenderApprise(Processor, Notifier):
         apobj.notify(
             body=message,
             title=title,
-            attach=images,
+            attach=attach,
             body_format=apprise.NotifyFormat.TEXT,
         )

--- a/flathunter/notifiers/sender_apprise.py
+++ b/flathunter/notifiers/sender_apprise.py
@@ -13,6 +13,7 @@ class SenderApprise(Processor, Notifier):
         self.config = config
         self.apprise_urls = self.config.get('apprise', {})
         self.__notify_with_images: bool = self.config.apprise_notify_with_images()
+        self.__image_limit = self.config.apprise_image_limit()
 
     def process_expose(self, expose):
         """Send a message to a user describing the expose"""
@@ -36,13 +37,16 @@ class SenderApprise(Processor, Notifier):
             address=expose.get('address', 'N/A'),
             durations=expose.get('durations', 'N/A')
         ).strip()
-        images = expose.get('images', [expose.get('image')])[:6]\
-            if self.__notify_with_images else None
+        images = (
+            expose.get("images", [expose.get("image")])[: self.__image_limit]
+            if self.__notify_with_images
+            else None
+        )
         self.__send_msg(message, title, images)
         return expose
 
     def notify(self, message: str):
-        """ Send the given message to users """
+        """Send the given message to users"""
         self.__send_msg(message=message, title=None, images=None)
 
     def __send_msg(self, message, title, images):


### PR DESCRIPTION
This is an addition to #563.

I somehow missed that the attachment limit imposed by the apprise-api service [can be configured](https://github.com/caronc/apprise-api/blob/d1c5d64b2eccbda43ce5b878f9d8b2c3b4a3488b/apprise_api/core/settings/__init__.py#L208) so IMO there shouldn't be a fixed limit of attachments sent by flathunter.

Sorry for not thoroughly checking before opening the other PR.