### PR TITLE
fix: Removed " Zi." from ImmoWelt rooms text parsing

### DIFF
--- a/flathunter/crawler/immowelt.py
+++ b/flathunter/crawler/immowelt.py
@@ -71,7 +71,7 @@ class Immowelt(Crawler):
 
             try:
                 rooms = expose_ids[idx].find(
-                    "div", attrs={"data-test": "rooms"}).text
+                    "div", attrs={"data-test": "rooms"}).text.replace(" Zi.", "")
             except IndexError:
                 rooms = ""
 


### PR DESCRIPTION
ImmoWelt shows room numbers as ```[COUNT] Zi.``` (e.g. ```3 Zi.```). 

This has not been taken into account before, which leads to displays like this:

flathunter.codders.de:
![Screenshot 2024-06-18 at 12 00 44](https://github.com/flathunters/flathunter/assets/34438048/f73439b4-ad91-4901-9ec6-e26e6d10cd14)

Telegram:
![Screenshot 2024-06-18 at 12 02 09](https://github.com/flathunters/flathunter/assets/34438048/1fee4d17-f3e5-46c1-9fb0-7f42bbdd8a43)

