### PR TITLE
Fix Immoscout24 Captcha Resolution

### DIFF
--- a/flathunter/abstract_crawler.py
+++ b/flathunter/abstract_crawler.py
@@ -3,6 +3,7 @@ from abc import ABC
 import re
 from time import sleep
 from typing import Optional, Any
+import json
 
 import backoff
 import requests
@@ -70,6 +71,8 @@ class Crawler(ABC):
             driver.get(url)
             if re.search("initGeetest", driver.page_source):
                 self.resolve_geetest(driver)
+            elif re.search("awswaf-captcha", driver.page_source):
+                self.resolve_awsawf(driver)
             elif re.search("g-recaptcha", driver.page_source):
                 self.resolve_recaptcha(
                     driver, checkbox, afterlogin_string or "")
@@ -189,6 +192,71 @@ class Crawler(ABC):
                       f'data: "{data}"}});')
             driver.execute_script(script)
             sleep(2)
+        except CaptchaUnsolvableError:
+            driver.refresh()
+            raise
+
+    @backoff.on_exception(wait_gen=backoff.constant,
+                        exception=CaptchaUnsolvableError,
+                        max_tries=3)
+    def resolve_awsawf(self, driver):
+        """Resolve AWS WAF Captcha"""
+
+        # Intercept background network traffic via log sniffing
+        sleep(2)
+        logs_raw = driver.get_log("performance")
+        logs = [json.loads(lr["message"])["message"] for lr in logs_raw]
+        
+        def log_filter(log_):
+            return (
+                # is an actual response
+                log_["method"] == "Network.responseReceived"
+                # and json
+                and "json" in log_["params"]["response"]["mimeType"]
+            )
+        
+        for log in filter(log_filter, logs):
+            request_id = log["params"]["requestId"]
+            resp_url = log["params"]["response"]["url"]
+            if "problem" in resp_url and "awswaf" in resp_url:
+                response = driver.execute_cdp_cmd("Network.getResponseBody", {"requestId": request_id})
+                response_json = json.loads(response["body"])
+                iv = response_json["state"]["iv"]
+                context = response_json["state"]["payload"]
+                sitekey = response_json["key"]
+
+
+        sitekey = re.findall(
+            r"apiKey: \"(.*?)\"", driver.page_source)[0]
+
+        patternChallenge = r'src="([^"]*challenge\.js)"'
+        challenge_matches = re.findall(patternChallenge, driver.page_source)
+        for match in challenge_matches:
+            print(f'Challenge SRC Value: {match}')   
+            challenge = match
+
+        patternJsApi = r'src="([^"]*jsapi\.js)"'
+        jsapi_matches = re.findall(patternJsApi, driver.page_source)
+        for match in jsapi_matches:
+            print(f'JsApi SRC Value: {match}')   
+            jsapi = match
+
+        try:
+            captcha = self.captcha_solver.solve_awswaf(
+                sitekey,
+                iv,
+                context,
+                challenge,
+                jsapi,
+                driver.current_url
+            )
+            old_cookie = driver.get_cookie('aws-waf-token')
+            new_cookie = old_cookie
+            new_cookie['value'] = captcha.token
+            driver.delete_cookie('aws-waf-token')
+            driver.add_cookie(new_cookie)
+            sleep(1)
+            driver.refresh()
         except CaptchaUnsolvableError:
             driver.refresh()
             raise

--- a/flathunter/captcha/capmonster_solver.py
+++ b/flathunter/captcha/capmonster_solver.py
@@ -1,0 +1,73 @@
+"""Captcha solver for CapMonster Captcha Solving Service (https://capmonster.cloud)"""
+import json
+from typing import Dict
+from time import sleep
+import backoff
+import requests
+
+from flathunter.logging import logger
+from flathunter.captcha.captcha_solver import (
+    CaptchaSolver,
+    CaptchaBalanceEmpty,
+    CaptchaUnsolvableError,
+    GeetestResponse,
+    AwsAwfResponse,
+    RecaptchaResponse,
+)
+
+class CapmonsterSolver(CaptchaSolver):
+    """Implementation of Captcha solver for CapMonster"""
+  
+    
+    def solve_awswaf(self, sitekey: str, iv: str, context: str, challenge_script: str, captcha_script: str, page_url: str) -> AwsAwfResponse:
+        """Solves AWS WAF Captcha"""
+        logger.info("Trying to solve AWS WAF.")
+        params = {
+            "clientKey": self.api_key,
+            "task": {
+                "type": "AmazonTaskProxyless",
+                "websiteURL": page_url,
+                "challengeScript": "",
+                "captchaScript": captcha_script,
+                "websiteKey": sitekey,
+                "context": "",
+                "iv": "",
+                "cookieSolution": True
+            }
+        }
+        captcha_id = self.__submit_capmonster_request(params)
+        untyped_result = self.__retrieve_capmonster_result(captcha_id)
+        return AwsAwfResponse(untyped_result)
+
+    @backoff.on_exception(**CaptchaSolver.backoff_options)
+    def __submit_capmonster_request(self, params: Dict[str, str]) -> str:
+        submit_url = "https://api.capmonster.cloud/createTask"
+        submit_response = requests.post(submit_url, json=params, timeout=30)
+        logger.info("Got response from capmonster: %s", submit_response.text)
+
+        response_json = submit_response.json()
+
+        return response_json["taskId"]
+
+
+    @backoff.on_exception(**CaptchaSolver.backoff_options)
+    def __retrieve_capmonster_result(self, captcha_id: str):
+        retrieve_url = "https://api.capmonster.cloud/getTaskResult"
+        params = {
+            "clientKey": self.api_key,
+            "taskId": captcha_id
+        }
+        while True:
+            retrieve_response = requests.get(retrieve_url, json=params, timeout=30)
+            logger.debug("Got response from capmonster: %s", retrieve_response.text)
+
+            response_json = retrieve_response.json()
+            if not "status" in response_json:
+                raise requests.HTTPError(response=response_json["errrorCode"])
+
+            if response_json["status"] == "processing":
+                logger.info("Captcha is not ready yet, waiting...")
+                sleep(5)
+                continue
+            if response_json["status"] == "ready":
+                return response_json["solution"]["cookies"]["aws-waf-token"]

--- a/flathunter/captcha/captcha_solver.py
+++ b/flathunter/captcha/captcha_solver.py
@@ -17,6 +17,11 @@ class RecaptchaResponse:
     """Response from reCAPTCHA"""
     result: str
 
+@dataclass
+class AwsAwfResponse:
+    """Response from AWS WAF"""
+    token: str
+
 
 class CaptchaSolver:
     """Interface for Captcha solvers"""
@@ -31,6 +36,10 @@ class CaptchaSolver:
         self.api_key = api_key
 
     def solve_geetest(self, geetest: str, challenge: str, page_url: str) -> GeetestResponse:
+        """Should be implemented in subclass"""
+        raise NotImplementedError()
+    
+    def solve_awswaf(self, sitekey: str, iv: str, context: str, page_url: str) -> AwsAwfResponse:
         """Should be implemented in subclass"""
         raise NotImplementedError()
 

--- a/flathunter/captcha/twocaptcha_solver.py
+++ b/flathunter/captcha/twocaptcha_solver.py
@@ -34,27 +34,6 @@ class TwoCaptchaSolver(CaptchaSolver):
         return GeetestResponse(untyped_result["geetest_challenge"],
                                untyped_result["geetest_validate"],
                                untyped_result["geetest_seccode"])
-    
-    
-    def solve_awswaf(self, sitekey: str, iv: str, context: str, challenge_script: str, captcha_script: str, page_url: str) -> AwsAwfResponse:
-        """Solves AWS WAF Captcha"""
-        logger.info("Trying to solve AWS WAF.")
-        params = {
-            "clientKey": "bafad5d1c0f567b8f2f4312c02340ba2",
-            "task": {
-                "type": "AmazonTaskProxyless",
-                "websiteURL": page_url,
-                "challengeScript": "",
-                "captchaScript": captcha_script,
-                "websiteKey": sitekey,
-                "context": "",
-                "iv": "",
-                "cookieSolution": True
-            }
-        }
-        captcha_id = self.__submit_capmonster_request(params)
-        untyped_result = self.__retrieve_capmonster_result(captcha_id)
-        return AwsAwfResponse(untyped_result)
 
 
     def solve_recaptcha(self, google_site_key: str, page_url: str) -> RecaptchaResponse:
@@ -111,36 +90,3 @@ class TwoCaptchaSolver(CaptchaSolver):
                 raise requests.HTTPError(response=retrieve_response)
 
             return retrieve_response.text.split("|", 1)[1]
-
-    @backoff.on_exception(**CaptchaSolver.backoff_options)
-    def __submit_capmonster_request(self, params: Dict[str, str]) -> str:
-        submit_url = "https://api.capmonster.cloud/createTask"
-        submit_response = requests.post(submit_url, json=params, timeout=30)
-        logger.info("Got response from capmonster: %s", submit_response.text)
-
-        response_json = submit_response.json()
-
-        return response_json["taskId"]
-
-
-    @backoff.on_exception(**CaptchaSolver.backoff_options)
-    def __retrieve_capmonster_result(self, captcha_id: str):
-        retrieve_url = "https://api.capmonster.cloud/getTaskResult"
-        params = {
-            "clientKey": "bafad5d1c0f567b8f2f4312c02340ba2",
-            "taskId": captcha_id
-        }
-        while True:
-            retrieve_response = requests.get(retrieve_url, json=params, timeout=30)
-            logger.debug("Got response from capmonster: %s", retrieve_response.text)
-
-            response_json = retrieve_response.json()
-            if not "status" in response_json:
-                raise requests.HTTPError(response=response_json["errrorCode"])
-
-            if response_json["status"] == "processing":
-                logger.info("Captcha is not ready yet, waiting...")
-                sleep(5)
-                continue
-            if response_json["status"] == "ready":
-                return response_json["solution"]["cookies"]["aws-waf-token"]

--- a/flathunter/captcha/twocaptcha_solver.py
+++ b/flathunter/captcha/twocaptcha_solver.py
@@ -11,6 +11,7 @@ from flathunter.captcha.captcha_solver import (
     CaptchaBalanceEmpty,
     CaptchaUnsolvableError,
     GeetestResponse,
+    AwsAwfResponse,
     RecaptchaResponse,
 )
 
@@ -33,6 +34,27 @@ class TwoCaptchaSolver(CaptchaSolver):
         return GeetestResponse(untyped_result["geetest_challenge"],
                                untyped_result["geetest_validate"],
                                untyped_result["geetest_seccode"])
+    
+    
+    def solve_awswaf(self, sitekey: str, iv: str, context: str, challenge_script: str, captcha_script: str, page_url: str) -> AwsAwfResponse:
+        """Solves AWS WAF Captcha"""
+        logger.info("Trying to solve AWS WAF.")
+        params = {
+            "clientKey": "bafad5d1c0f567b8f2f4312c02340ba2",
+            "task": {
+                "type": "AmazonTaskProxyless",
+                "websiteURL": page_url,
+                "challengeScript": "",
+                "captchaScript": captcha_script,
+                "websiteKey": sitekey,
+                "context": "",
+                "iv": "",
+                "cookieSolution": True
+            }
+        }
+        captcha_id = self.__submit_capmonster_request(params)
+        untyped_result = self.__retrieve_capmonster_result(captcha_id)
+        return AwsAwfResponse(untyped_result)
 
 
     def solve_recaptcha(self, google_site_key: str, page_url: str) -> RecaptchaResponse:
@@ -51,7 +73,7 @@ class TwoCaptchaSolver(CaptchaSolver):
     def __submit_2captcha_request(self, params: Dict[str, str]) -> str:
         submit_url = "http://2captcha.com/in.php"
         submit_response = requests.post(submit_url, params=params, timeout=30)
-        logger.debug("Got response from 2captcha/in: %s", submit_response.text)
+        logger.info("Got response from 2captcha/in: %s", submit_response.text)
 
         if not submit_response.text.startswith("OK"):
             raise requests.HTTPError(response=submit_response)
@@ -66,6 +88,7 @@ class TwoCaptchaSolver(CaptchaSolver):
             "key": self.api_key,
             "action": "get",
             "id": captcha_id,
+            "json": 0,
         }
         while True:
             retrieve_response = requests.get(retrieve_url, params=params, timeout=30)
@@ -88,3 +111,36 @@ class TwoCaptchaSolver(CaptchaSolver):
                 raise requests.HTTPError(response=retrieve_response)
 
             return retrieve_response.text.split("|", 1)[1]
+
+    @backoff.on_exception(**CaptchaSolver.backoff_options)
+    def __submit_capmonster_request(self, params: Dict[str, str]) -> str:
+        submit_url = "https://api.capmonster.cloud/createTask"
+        submit_response = requests.post(submit_url, json=params, timeout=30)
+        logger.info("Got response from capmonster: %s", submit_response.text)
+
+        response_json = submit_response.json()
+
+        return response_json["taskId"]
+
+
+    @backoff.on_exception(**CaptchaSolver.backoff_options)
+    def __retrieve_capmonster_result(self, captcha_id: str):
+        retrieve_url = "https://api.capmonster.cloud/getTaskResult"
+        params = {
+            "clientKey": "bafad5d1c0f567b8f2f4312c02340ba2",
+            "taskId": captcha_id
+        }
+        while True:
+            retrieve_response = requests.get(retrieve_url, json=params, timeout=30)
+            logger.debug("Got response from capmonster: %s", retrieve_response.text)
+
+            response_json = retrieve_response.json()
+            if not "status" in response_json:
+                raise requests.HTTPError(response=response_json["errrorCode"])
+
+            if response_json["status"] == "processing":
+                logger.info("Captcha is not ready yet, waiting...")
+                sleep(5)
+                continue
+            if response_json["status"] == "ready":
+                return response_json["solution"]["cookies"]["aws-waf-token"]

--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -59,13 +59,12 @@ def get_chrome_driver(driver_arguments):
     """Configure Chrome WebDriver"""
     logger.info('Initializing Chrome WebDriver for crawler...')
     chrome_options = uc.ChromeOptions() # pylint: disable=no-member
-    if platform == "darwin":
-        chrome_options.add_argument("--headless")
     if driver_arguments is not None:
         for driver_argument in driver_arguments:
             chrome_options.add_argument(driver_argument)
     chrome_version = get_chrome_version()
     chrome_options.add_argument("--headless=new")
+    chrome_options.set_capability('goog:loggingPrefs', {'performance': 'ALL'})
     driver = uc.Chrome(version_main=chrome_version, options=chrome_options) # pylint: disable=no-member
 
     driver.execute_cdp_cmd(

--- a/flathunter/config.py
+++ b/flathunter/config.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from flathunter.captcha.captcha_solver import CaptchaSolver
 from flathunter.captcha.imagetyperz_solver import ImageTyperzSolver
 from flathunter.captcha.twocaptcha_solver import TwoCaptchaSolver
+from flathunter.captcha.capmonster_solver import CapmonsterSolver
 from flathunter.crawler.kleinanzeigen import Kleinanzeigen
 from flathunter.crawler.idealista import Idealista
 from flathunter.crawler.immobiliare import Immobiliare
@@ -36,6 +37,7 @@ class Env:
     # Captcha setup
     FLATHUNTER_2CAPTCHA_KEY = _read_env("FLATHUNTER_2CAPTCHA_KEY")
     FLATHUNTER_IMAGETYPERZ_TOKEN = _read_env("FLATHUNTER_IMAGETYPERZ_TOKEN")
+    FLATHUNTER_CAPMONSTER_KEY = _read_env("FLATHUNTER_CAPMONSTER_KEY")
     FLATHUNTER_HEADLESS_BROWSER = _read_env("FLATHUNTER_HEADLESS_BROWSER")
     FLATHUNTER_IS24_COOKIE = _read_env("FLATHUNTER_IS24_COOKIE")
 
@@ -300,6 +302,10 @@ Preis: {price}
     def get_twocaptcha_key(self) -> str:
         """API Token for 2captcha"""
         return self._read_yaml_path("captcha.2captcha.api_key", "")
+    
+    def get_capmonster_key(self) -> str:
+        """API Token for Capmonster"""
+        return self._read_yaml_path("captcha.capmonster.api_key", "")
 
     def _get_captcha_solver(self) -> Optional[CaptchaSolver]:
         """Get configured captcha solver"""
@@ -310,6 +316,10 @@ Preis: {price}
         twocaptcha_api_key = self.get_twocaptcha_key()
         if twocaptcha_api_key:
             return TwoCaptchaSolver(twocaptcha_api_key)
+        
+        capmonster_api_key = self.get_capmonster_key()
+        if capmonster_api_key:
+            return CapmonsterSolver(capmonster_api_key)
 
         return None
 
@@ -399,6 +409,10 @@ class CaptchaEnvironmentConfig(YamlConfig):
     def get_twocaptcha_key(self) -> str:
         """Return the currently configured 2captcha API key"""
         return Env.FLATHUNTER_2CAPTCHA_KEY() or super().get_twocaptcha_key()  # pylint: disable=no-member
+    
+    def get_capmonster_key(self) -> str:
+        """Return the currently configured Capmonster API key"""
+        return Env.FLATHUNTER_CAPMONSTER_KEY() or super().get_capmonster_key()
 
     def captcha_driver_arguments(self):
         """The list of driver arguments for Selenium / Webdriver"""

--- a/flathunter/crawler/immobilienscout.py
+++ b/flathunter/crawler/immobilienscout.py
@@ -124,6 +124,7 @@ class Immobilienscout(Crawler):
                 logger.error(
                     "IS24 bot detection has identified our script as a bot - we've been blocked"
                 )
+                logger.info(self.get_driver_force().page_source)
             return []
         return self.get_entries_from_json(result_json)
 


### PR DESCRIPTION
Solves #577 #589 #513

Immoscout seems to have entirely moved from GeeTest to AWS WAF Captcha.
This PR implments a new solver Capmonster to deal with that fact.

My reasoning behind that:
After trying for hours to get any of the existing captcha solvers to work with the new clientside AWS WAF javascript captchas, I caved and implemented @jukoson's fix using capmonster as a solver in a way that mimics the other implementations.
It should be entirely backwards compatible

To use the new solver just modify your ENV variables or config:
```
captcha:
  capmonster:
    api_key: meow
```

Shortcomings:
- The new solver implementation only supports the aws captcha for now, but I can change that down the line.
- There is also some leftover code that in theory sniffs on background requests to get iv, context (or whatever it is now), etc from the loaded javascript. However supplying all that additional information leads to unsolvable captchas for whatever reasons and yields wrong results with 2captcha in my trials. Thats why these values are discarded in the solver itself.
- The accidentally leaked API keys included in one commit have been rotated :D 

Hope this helps!