### PR TITLE
fix capmonster json key

### DIFF
--- a/flathunter/captcha/capmonster_solver.py
+++ b/flathunter/captcha/capmonster_solver.py
@@ -77,7 +77,7 @@ class CapmonsterSolver(CaptchaSolver):
 
             response_json = retrieve_response.json()
             if not "status" in response_json:
-                raise requests.HTTPError(response=response_json["errrorCode"])
+                raise requests.HTTPError(response=response_json["errorCode"])
 
             if response_json["status"] == "processing":
                 logger.info("Captcha is not ready yet, waiting...")


### PR DESCRIPTION
Noticed that the error json key has a typo while I got this json response from capmonster in headless mode (possibly another bug as it is always working with headed chrome):
`{'errorId': 1, 'errorCode': 'ERROR_CAPTCHA_UNSOLVABLE', 'errorDescription': 'This type of captchas is not supported by the service or the image does not contain an answer, perhaps it is too noisy. It could also mean that the image is corrupted or was incorrectly rendered. '}`