### PR TITLE
fix chrome not being forced to headless mode for macOS

### DIFF
--- a/flathunter/chrome_wrapper.py
+++ b/flathunter/chrome_wrapper.py
@@ -59,13 +59,12 @@ def get_chrome_driver(driver_arguments):
     """Configure Chrome WebDriver"""
     logger.info('Initializing Chrome WebDriver for crawler...')
     chrome_options = uc.ChromeOptions() # pylint: disable=no-member
-    if platform == "darwin":
-        chrome_options.add_argument("--headless")
     if driver_arguments is not None:
         for driver_argument in driver_arguments:
             chrome_options.add_argument(driver_argument)
     chrome_version = get_chrome_version()
-    chrome_options.add_argument("--headless=new")
+    if(platform != "darwin"):
+        chrome_options.add_argument("--headless=new")
     chrome_options.set_capability('goog:loggingPrefs', {'performance': 'ALL'})
     driver = uc.Chrome(version_main=chrome_version, options=chrome_options) # pylint: disable=no-member
 


### PR DESCRIPTION
Hello again :)
Why is Chrome for macOS forced to always be in headless mode?

Besides that `chrome_options.add_argument("--headless=new")` also caused a problem on my Mac M1 (macOS 15.2) that I mentioned in this PR #670.
In my `config.yaml` I don't have any `driver_arguments` specified.