### PR TITLE
fix: rooms and size on kleinanzeigen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ celerybeat-schedule
 # dotenv
 .env
 .env.*
+.venv
 
 # virtualenv
 venv/


### PR DESCRIPTION
I had some problems with Kleinanzeigen lately, so I decided to have a look.
The rooms and apartment size weren't extracted correctly.

I've updated it, so the data is now extracted from the new string it is in.

(Also an add to the .gitignore since me and some other people I know use .venv for their virtual environments. I can remove that if you want)