### PR TITLE
Fix error handling in Immowelt crawler module

### DIFF
--- a/flathunter/crawler/immowelt.py
+++ b/flathunter/crawler/immowelt.py
@@ -102,7 +102,7 @@ class Immowelt(Crawler):
                 address = adv.find(
                     "div", attrs={"data-testid": "cardmfe-description-box-address"}
                   ).text
-            except (IndexError, AttributeError):
+            except AttributeError:
                 address = ""
             ad_id = url.split('/')[-1]
             processed_id = int(


### PR DESCRIPTION
Fixes uncaught `AttributeError` and `TypeError` exceptions and removes obsolete handling of `IndexError`